### PR TITLE
Optionally accept iverilog simulator options

### DIFF
--- a/migen/sim/icarus.py
+++ b/migen/sim/icarus.py
@@ -10,9 +10,11 @@ def _str2file(filename, contents):
 	f.close()
 
 class Runner:
-	def __init__(self, extra_files=None, top_file="migensim_top.v", dut_file="migensim_dut.v", vvp_file=None, keep_files=False):
+	def __init__(self, options=None, extra_files=None, top_file="migensim_top.v", dut_file="migensim_dut.v", vvp_file=None, keep_files=False):
 		if extra_files is None: extra_files = []
 		if vvp_file is None: vvp_file = dut_file + "vp"
+		if options is None: options = []
+		self.options = options
 		self.extra_files = extra_files
 		self.top_file = top_file
 		self.dut_file = dut_file
@@ -22,7 +24,7 @@ class Runner:
 	def start(self, c_top, c_dut):
 		_str2file(self.top_file, c_top)
 		_str2file(self.dut_file, c_dut)
-		subprocess.check_call(["iverilog", "-o", self.vvp_file, self.top_file, self.dut_file] + self.extra_files)
+		subprocess.check_call(["iverilog", "-o", self.vvp_file] + self.options + [self.top_file, self.dut_file] + self.extra_files)
 		self.process = subprocess.Popen(["vvp", "-mmigensim", self.vvp_file])
 
 	def __del__(self):


### PR DESCRIPTION
I have found it useful to be able to pass options to the iverilog process, such as additional include directories
