### PR TITLE
actorlib/fifo: fix no-op assignment due to .payload omission

### DIFF
--- a/migen/actorlib/fifo.py
+++ b/migen/actorlib/fifo.py
@@ -18,7 +18,7 @@ class _FIFOActor(Module):
 			self.fifo.din.eq(self.sink.payload),
 
 			self.source.stb.eq(self.fifo.readable),
-			self.source.eq(self.fifo.dout),
+			self.source.payload.eq(self.fifo.dout),
 			self.fifo.re.eq(self.source.ack)
 		]
 


### PR DESCRIPTION
This fixes a bug introduced by 07c33279c, which removed .payload in many places, including this one where it breaks the FIFO actors.
