### PR TITLE
Exception now has helpful string.

### DIFF
--- a/migen/fhdl/structure.py
+++ b/migen/fhdl/structure.py
@@ -107,7 +107,8 @@ class _Value(DUID):
                 return Cat(self[i] for i in range(start, stop, step))
             return _Slice(self, start, stop)
         else:
-            raise TypeError
+            raise TypeError("Can use type {} ({}) as key".format(
+                type(key), repr(key)))
 
     def eq(self, r):
         """Assignment


### PR DESCRIPTION
Before;
```
  File "/usr/local/google/home/tansell/foss/timvideos/hdmi2usb/i2cslave/build/lib/python3.4/site-packages/migen-0.2-py3
.4.egg/migen/fhdl/structure.py", line 110, in __getitem__
    raise TypeError
TypeError
```

After;
```
  File "/usr/local/google/home/tansell/foss/timvideos/hdmi2usb/i2cslave/build/lib/python3.4/site-packages/migen-0.2-py3.4.egg/migen/fhdl/structure.py", line 110, in __getitem__
    raise TypeError("Can use type %s (%r) as key" % (type(key), key))
TypeError: Can use type <class 'migen.fhdl.structure.Signal'> (<Signal dbits at 0x7fd7836a2a90>) as key
```