### PR TITLE
Add 'depth' attribute to _FIFOInterface

### DIFF
--- a/migen/genlib/fifo.py
+++ b/migen/genlib/fifo.py
@@ -57,6 +57,7 @@ class _FIFOInterface:
         self.din = Signal(width)
         self.dout = Signal(width)
         self.width = width
+        self.depth = depth
 
 
 class SyncFIFO(Module, _FIFOInterface):


### PR DESCRIPTION
There's a 'width' attribute -- so why no 'depth', too?