### PR TITLE
cdc: make pipelined registers reset_less

### DIFF
--- a/migen/genlib/cdc.py
+++ b/migen/genlib/cdc.py
@@ -19,7 +19,8 @@ class MultiRegImpl(Module):
         self.odomain = odomain
 
         w, signed = value_bits_sign(self.i)
-        self.regs = [Signal((w, signed)) for i in range(n)]
+        self.regs = [Signal((w, signed), reset_less=True)
+                for i in range(n)]
 
         ###
 
@@ -67,9 +68,9 @@ class PulseSynchronizer(Module):
 
         ###
 
-        toggle_i = Signal()
-        toggle_o = Signal()
-        toggle_o_r = Signal()
+        toggle_i = Signal(reset_less=True)
+        toggle_o = Signal()  # registered reset_less by MultiReg
+        toggle_o_r = Signal(reset_less=True)
 
         sync_i = getattr(self.sync, idomain)
         sync_o = getattr(self.sync, odomain)
@@ -88,7 +89,7 @@ class BusSynchronizer(Module):
     ``MultiReg``)."""
     def __init__(self, width, idomain, odomain, timeout=128):
         self.i = Signal(width)
-        self.o = Signal(width)
+        self.o = Signal(width, reset_less=True)
 
         if width == 1:
             self.specials += MultiReg(self.i, self.o, odomain)
@@ -108,8 +109,8 @@ class BusSynchronizer(Module):
                 self._pong.i.eq(self._ping.i)
             ]
 
-            ibuffer = Signal(width)
-            obuffer = Signal(width)
+            ibuffer = Signal(width, reset_less=True)
+            obuffer = Signal(width)  # registered reset_less by MultiReg
             sync_i += If(self._pong.o, ibuffer.eq(self.i))
             ibuffer.attr.add("no_retiming")
             self.specials += MultiReg(ibuffer, obuffer, odomain)
@@ -119,7 +120,7 @@ class BusSynchronizer(Module):
 class GrayCounter(Module):
     def __init__(self, width):
         self.ce = Signal()
-        self.q = Signal(width)
+        self.q = Signal(width, reset_less=True)
         self.q_next = Signal(width)
         self.q_binary = Signal(width)
         self.q_next_binary = Signal(width)
@@ -143,7 +144,7 @@ class GrayCounter(Module):
 class GrayDecoder(Module):
     def __init__(self, width):
         self.i = Signal(width)
-        self.o = Signal(width)
+        self.o = Signal(width, reset_less=True)
 
         # # #
 
@@ -206,7 +207,7 @@ def lcm(a, b):
 class Gearbox(Module):
     def __init__(self, iwidth, idomain, owidth, odomain):
         self.i = Signal(iwidth)
-        self.o = Signal(owidth)
+        self.o = Signal(owidth, reset_less=True)
 
         # # #
 
@@ -224,7 +225,7 @@ class Gearbox(Module):
         ]
         self.clock_domains += cd_write, cd_read
 
-        storage = Signal(2*lcm(iwidth, owidth))
+        storage = Signal(2*lcm(iwidth, owidth), reset_less=True)
         wrchunks = len(storage)//iwidth
         rdchunks = len(storage)//owidth
         wrpointer = Signal(max=wrchunks, reset=0 if iwidth > owidth else wrchunks//2)

--- a/migen/genlib/cdc.py
+++ b/migen/genlib/cdc.py
@@ -120,7 +120,7 @@ class BusSynchronizer(Module):
 class GrayCounter(Module):
     def __init__(self, width):
         self.ce = Signal()
-        self.q = Signal(width, reset_less=True)
+        self.q = Signal(width)
         self.q_next = Signal(width)
         self.q_binary = Signal(width)
         self.q_next_binary = Signal(width)


### PR DESCRIPTION
data in pipelined registers is guaranteed to be clocked in from source
signals at "full rate" and fully determined by those source registers.
in that sense these registers don't hold intrinsic state that needs to
be reset explicitly. their data can just flow in from the source (which
is reset).
having them reset_less delays their reset by one (or a few) clock cycles.
if the target CD is reset, the data would just be reset for the duration
of the target CD reset and then ("slowly") transition back to what the
source CD has.
control and handshaking logic needs to be reset.