### PR TITLE
Add TinyFPGA B Platform

### DIFF
--- a/migen/build/lattice/programmer.py
+++ b/migen/build/lattice/programmer.py
@@ -47,3 +47,8 @@ class TinyFpgaBProgrammer(GenericProgrammer):
     def flash(self, address, bitstream_file):
         subprocess.call(["tinyfpgab", "-a", str(address), "-p",
                         bitstream_file])
+
+    # Force user image to boot if a user reset tinyfpga, the bootloader
+    # is active, and the user image need not be reprogrammed.
+    def boot(self):
+        subprocess.call(["tinyfpgab", "-b"])

--- a/migen/build/lattice/programmer.py
+++ b/migen/build/lattice/programmer.py
@@ -37,3 +37,13 @@ class IceBurnProgrammer(GenericProgrammer):
 
     def load_bitstream(self, bitstream_file):
         subprocess.call([self.iceburn, "-evw", bitstream_file])
+
+
+class TinyFpgaBProgrammer(GenericProgrammer):
+    needs_bitreverse = False
+
+    # The default flash address you probably want is 0x30000; the image at
+    # address 0 is for the bootloader.
+    def flash(self, address, bitstream_file):
+        subprocess.call(["tinyfpgab", "-a", str(address), "-p",
+                        bitstream_file])

--- a/migen/build/platforms/tinyfpga_b.py
+++ b/migen/build/platforms/tinyfpga_b.py
@@ -1,0 +1,40 @@
+from migen.build.generic_platform import *
+from migen.build.lattice import LatticePlatform
+from migen.build.lattice.programmer import TinyFpgaBProgrammer
+
+_io = [
+    ("usb", 0,
+        Subsignal("d_p", Pins("A3")),
+        Subsignal("d_n", Pins("A4")),
+        IOStandard("LVCMOS33")
+    ),
+
+    ("spiflash", 0,
+        Subsignal("cs_n", Pins("F7"), IOStandard("LVCMOS33")),
+        Subsignal("clk", Pins("G7"), IOStandard("LVCMOS33")),
+        Subsignal("mosi", Pins("G6"), IOStandard("LVCMOS33")),
+        Subsignal("miso", Pins("H7"), IOStandard("LVCMOS33"))
+    ),
+
+    ("clk16", 0, Pins("B4"), IOStandard("LVCMOS33"))
+]
+
+_connectors = [
+    # B2-J1, Pins 4-13
+    # D9-C9, Pins 18-19, Pins 21-24
+    # E8, Pin 20 (Input only)
+    ("GPIO", "B2 A2 A1 B1 C1 D1 E1 G1 H1 J1 D9 C9 A9 A8 A7 A6"),
+    ("GBIN", "E8")
+]
+
+
+class Platform(LatticePlatform):
+    default_clk_name = "clk16"
+    default_clk_period = 62.5
+
+    def __init__(self):
+        LatticePlatform.__init__(self, "ice40-lp8k-cm81", _io, _connectors,
+                                 toolchain="icestorm")
+
+    def create_programmer(self):
+        return TinyFpgaBProgrammer()


### PR DESCRIPTION
[TinyFPGA B2](http://tinyfpga.com) is an Ice40-based FPGA board in a 28-pin breadboard-friendly form factor. It contains a minimum of peripherals, mainly deferring I/O to headers, but is notable for exposing a USB port as I/O. The official repository provides [a reference design](https://github.com/tinyfpga/TinyFPGA-B-Series/tree/master/bootloader) implementing a USB device.

This PR depends on #84 being merged first to actually function, but since both PRs are ready and don't conflict, I figured I'd open this one in parallel.