### PR TITLE
Add Platform-specific tests

### DIFF
--- a/migen/test/test_platform.py
+++ b/migen/test/test_platform.py
@@ -45,5 +45,10 @@ class TestExamplesPlatform(unittest.TestCase):
     pass
 
 for mod, name in _find_platforms(migen.build.platforms):
-    setattr(TestExamplesPlatform, "test_" + name,
-            _make_platform_test_method(mod, name))
+    # Roach has no default clock, so expect failure.
+    if name == "roach":
+        test_fcn = unittest.expectedFailure(_make_platform_test_method(mod,
+                                            name))
+    else:
+        test_fcn = _make_platform_test_method(mod, name)
+    setattr(TestExamplesPlatform, "test_" + name, test_fcn)

--- a/migen/test/test_platform.py
+++ b/migen/test/test_platform.py
@@ -1,0 +1,49 @@
+import unittest
+import importlib
+import pkgutil
+import shutil
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+import migen.build.platforms
+
+
+def _make_platform_test_method(mod, name):
+    def platform_test_method(self):
+        plat = importlib.import_module(mod).Platform()
+        m = TestModulePlatform(plat)
+        plat.build(m, run=False, build_name=name, build_dir=name)
+        shutil.rmtree(name)
+
+    return platform_test_method
+
+
+def _find_platforms(mod_root):
+    def mk_name(mod, child):
+        return ".".join([mod.__name__, child])
+
+    imports = []
+    for _, name, is_mod in pkgutil.walk_packages(mod_root.__path__):
+        if is_mod:
+            new_root = importlib.import_module(mk_name(mod_root, name))
+            imports.extend(_find_platforms(new_root))
+        else:
+            imports.append((mk_name(mod_root, name), name))
+    return imports
+
+
+class TestModulePlatform(Module):
+    def __init__(self, plat):
+        # FIXME: Somehow incorporate plat.request() into this.
+        inp = Signal()
+        out = Signal()
+
+        self.specials += MultiReg(inp, out)
+
+
+class TestExamplesPlatform(unittest.TestCase):
+    pass
+
+for mod, name in _find_platforms(migen.build.platforms):
+    setattr(TestExamplesPlatform, "test_" + name,
+            _make_platform_test_method(mod, name))


### PR DESCRIPTION
This PR adds `test_platform.py` to the unit tests. The new module recursively collects all supported platforms, creates a dummy `Module` for each platform, and ensures the output files for building with a toolchain are successfully generated.

Ideally, I would prefer to exercise `GenericPlatform.request()` functionality in `TestModulePlatform`, but I haven't figured out a clean way to probe available I/O and choose two (without making tests nondeterministic). Additionally `test_roach` is going to fail b/c there is no default clock, but as I suspect that is by design, I think it's acceptable.