### PR TITLE
Add Mercury Baseboard support

### DIFF
--- a/migen/build/platforms/mercury.py
+++ b/migen/build/platforms/mercury.py
@@ -1,4 +1,4 @@
-# This file is Copyright (c) 2015 William D. Jones <thor0505@comcast.net>
+# This file is Copyright (c) 2015, 2017 William D. Jones <thor0505@comcast.net>
 # License: BSD
 
 from migen.build.generic_platform import *
@@ -18,7 +18,7 @@ _io = [
         Subsignal("clk", Pins("P53"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P46"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P51"), IOStandard("LVTTL"))
-    ),
+     ),
 
     # FPGA is primary
     ("spiflash", 0,
@@ -26,14 +26,14 @@ _io = [
         Subsignal("clk", Pins("P53"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P46"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P51"), IOStandard("LVTTL"))
-    ),
+     ),
 
     ("spiflash2x", 0,
         Subsignal("cs_n", Pins("P27")),
         Subsignal("clk", Pins("P53")),
         Subsignal("dq", Pins("P46", "P51")),
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-    ),
+     ),
 
     # ADC over SPI- FPGA is primary
     ("adc", 0,
@@ -41,7 +41,7 @@ _io = [
         Subsignal("clk",  Pins("P9"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P10"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P21"), IOStandard("LVTTL"))
-    ),
+     ),
 
     # GPIO control- SRAM and connectors are shared: these pins control how
     # to access each. Recommended to combine with gpio_sram_bus extension,
@@ -52,7 +52,7 @@ _io = [
         Subsignal("bussw_oe_n", Pins("P30")),  # 5V tolerant GPIO is shared
         # w/ memory using this pin.
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-    )
+     )
 ]
 
 # Perhaps define some connectors as having a specific purpose- i.e. a 5V GPIO
@@ -67,8 +67,11 @@ _connectors = [
     # to FPGA)- LVCMOS33
     ("CLKIO", "P40 P44"),  # Clock IO (Can be used as GPIO)- LVCMOS33
     ("INPUT", "P68 P97 P7 P82"),  # Input-only pins- LVCMOS33
-    ("LED", "P13 P15 P16 P19")  # LEDs can be used as pins as well- LVTTL.
+    ("LED", "P13 P15 P16 P19"),  # LEDs can be used as pins as well- LVTTL.
+    ("PMOD", "P5 P4 P6 P98 P94 P93 P90 P89")  # Baseboard PMOD.
+    # Overlaps w/ GPIO bus.
 ]
+
 
 # Some default useful extensions- use platform.add_extension() to use, e.g.
 # from migen.build.platforms import mercury
@@ -94,7 +97,7 @@ gpio_sram = [
         # Subsignal("oe_n", Pins()),  # If OE wasn't tied to ground on Mercury,
         # this pin would be here.
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-    )
+     )
 ]
 
 # The "serial port" is in fact over SPI. The creators of the board provide a
@@ -104,8 +107,8 @@ gpio_sram = [
 serial = [
     ("serial", 0,
         Subsignal("tx", Pins("DIO:0"), IOStandard("LVCMOS33")),  # FTDI D1
-        Subsignal("rx", Pins("INPUT:0"), IOStandard("LVCMOS33"))
-    )   # FTDI D0
+        Subsignal("rx", Pins("INPUT:0"), IOStandard("LVCMOS33"))  # FTDI D0
+     )
 ]
 
 leds = [
@@ -115,9 +118,75 @@ leds = [
     ("user_led", 3, Pins("LED:3"), IOStandard("LVTTL"))
 ]
 
+
+# The remaining peripherals only make sense w/ the Baseboard installed.
 # See: http://www.micro-nova.com/mercury-baseboard/
-# Not implemented yet.
-baseboard = [
+sw = [
+    ("sw", 0, Pins("GPIO:0"), IOStandard("LVTTL")),
+    ("sw", 1, Pins("GPIO:1"), IOStandard("LVTTL")),
+    ("sw", 2, Pins("GPIO:2"), IOStandard("LVTTL")),
+    ("sw", 3, Pins("GPIO:3"), IOStandard("LVTTL")),
+    ("sw", 4, Pins("GPIO:4"), IOStandard("LVTTL")),
+    ("sw", 5, Pins("GPIO:5"), IOStandard("LVTTL")),
+    ("sw", 6, Pins("GPIO:6"), IOStandard("LVTTL")),
+    ("sw", 7, Pins("GPIO:7"), IOStandard("LVTTL"))
+]
+
+user_btn = [
+    ("user_btn", 1, Pins("INPUT:0"), IOStandard("LVTTL")),
+    ("user_btn", 2, Pins("INPUT:1"), IOStandard("LVTTL")),
+    ("user_btn", 3, Pins("INPUT:2"), IOStandard("LVTTL")),
+    ("user_btn", 4, Pins("INPUT:3"), IOStandard("LVTTL"))
+]
+
+vga = [
+    ("vga_out", 0,
+        Subsignal("hsync_n", Pins("LED:2"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST")),
+        Subsignal("vsync_n", Pins("LED:3"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST")),
+        Subsignal("r", Pins("DIO:0 DIO:1 DIO:2"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST")),
+        Subsignal("g", Pins("DIO:3 DIO:4 DIO:5"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST")),
+        Subsignal("b", Pins("DIO:6 CLKIO:0"), IOStandard("LVCMOS33"),
+                  Misc("SLEW=FAST"))
+     )
+]
+
+extclk = [
+    ("extclk", 0, Pins("CLKIO:1"), IOStandard("LVCMOS33"))
+]
+
+sevenseg = [
+    ("sevenseg", 0,
+        Subsignal("segment7", Pins("GPIO:12"), IOStandard("LVTTL")),  # A
+        Subsignal("segment6", Pins("GPIO:13"), IOStandard("LVTTL")),  # B
+        Subsignal("segment5", Pins("GPIO:14"), IOStandard("LVTTL")),  # C
+        Subsignal("segment4", Pins("GPIO:15"), IOStandard("LVTTL")),  # D
+        Subsignal("segment3", Pins("GPIO:16"), IOStandard("LVTTL")),  # E
+        Subsignal("segment2", Pins("GPIO:17"), IOStandard("LVTTL")),  # F
+        Subsignal("segment1", Pins("GPIO:18"), IOStandard("LVTTL")),  # G
+        Subsignal("segment0", Pins("GPIO:19"), IOStandard("LVTTL")),  # Dot
+        Subsignal("enable0", Pins("GPIO:8"), IOStandard("LVTTL")),   # EN0
+        Subsignal("enable1", Pins("GPIO:9"), IOStandard("LVTTL")),   # EN1
+        Subsignal("enable2", Pins("GPIO:10"), IOStandard("LVTTL")),  # EN2
+        Subsignal("enable3", Pins("GPIO:11"), IOStandard("LVTTL"))  # EN2
+     )
+]
+
+ps2 = [
+    ("ps2", 0,
+        Subsignal("clk", Pins("LED:1"), IOStandard("LVCMOS33")),
+        Subsignal("data", Pins("LED:0"), IOStandard("LVCMOS33"))
+     )
+]
+
+audio = [
+    ("audio", 0,
+        Subsignal("l", Pins("GPIO:29"), IOStandard("LVTTL")),
+        Subsignal("r", Pins("GPIO:28"), IOStandard("LVTTL"))
+     )
 ]
 
 

--- a/migen/build/platforms/mercury.py
+++ b/migen/build/platforms/mercury.py
@@ -18,7 +18,7 @@ _io = [
         Subsignal("clk", Pins("P53"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P46"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P51"), IOStandard("LVTTL"))
-     ),
+    ),
 
     # FPGA is primary
     ("spiflash", 0,
@@ -26,14 +26,14 @@ _io = [
         Subsignal("clk", Pins("P53"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P46"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P51"), IOStandard("LVTTL"))
-     ),
+    ),
 
     ("spiflash2x", 0,
         Subsignal("cs_n", Pins("P27")),
         Subsignal("clk", Pins("P53")),
         Subsignal("dq", Pins("P46", "P51")),
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-     ),
+    ),
 
     # ADC over SPI- FPGA is primary
     ("adc", 0,
@@ -41,7 +41,7 @@ _io = [
         Subsignal("clk",  Pins("P9"), IOStandard("LVTTL")),
         Subsignal("mosi", Pins("P10"), IOStandard("LVTTL")),
         Subsignal("miso", Pins("P21"), IOStandard("LVTTL"))
-     ),
+    ),
 
     # GPIO control- SRAM and connectors are shared: these pins control how
     # to access each. Recommended to combine with gpio_sram_bus extension,
@@ -52,7 +52,7 @@ _io = [
         Subsignal("bussw_oe_n", Pins("P30")),  # 5V tolerant GPIO is shared
         # w/ memory using this pin.
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-     )
+    )
 ]
 
 # Perhaps define some connectors as having a specific purpose- i.e. a 5V GPIO
@@ -97,7 +97,7 @@ gpio_sram = [
         # Subsignal("oe_n", Pins()),  # If OE wasn't tied to ground on Mercury,
         # this pin would be here.
         IOStandard("LVTTL"), Misc("SLEW=FAST")
-     )
+    )
 ]
 
 # The "serial port" is in fact over SPI. The creators of the board provide a
@@ -108,7 +108,7 @@ serial = [
     ("serial", 0,
         Subsignal("tx", Pins("DIO:0"), IOStandard("LVCMOS33")),  # FTDI D1
         Subsignal("rx", Pins("INPUT:0"), IOStandard("LVCMOS33"))  # FTDI D0
-     )
+    )
 ]
 
 leds = [
@@ -151,7 +151,7 @@ vga = [
                   Misc("SLEW=FAST")),
         Subsignal("b", Pins("DIO:6 CLKIO:0"), IOStandard("LVCMOS33"),
                   Misc("SLEW=FAST"))
-     )
+    )
 ]
 
 extclk = [
@@ -172,21 +172,21 @@ sevenseg = [
         Subsignal("enable1", Pins("GPIO:9"), IOStandard("LVTTL")),   # EN1
         Subsignal("enable2", Pins("GPIO:10"), IOStandard("LVTTL")),  # EN2
         Subsignal("enable3", Pins("GPIO:11"), IOStandard("LVTTL"))  # EN2
-     )
+    )
 ]
 
 ps2 = [
     ("ps2", 0,
         Subsignal("clk", Pins("LED:1"), IOStandard("LVCMOS33")),
         Subsignal("data", Pins("LED:0"), IOStandard("LVCMOS33"))
-     )
+    )
 ]
 
 audio = [
     ("audio", 0,
         Subsignal("l", Pins("GPIO:29"), IOStandard("LVTTL")),
         Subsignal("r", Pins("GPIO:28"), IOStandard("LVTTL"))
-     )
+    )
 ]
 
 


### PR DESCRIPTION
One of my first commits to Migen was to add the [Mercury](https://www.micro-nova.com/mercury) FPGA development board as a platform. About the same time I did, a peripheral for Mercury known as the [Baseboard](https://www.micro-nova.com/mercury-baseboard) was released. Not having a Baseboard, I put adding support as a TODO until I got one.

Well I got one pretty soon after that commit, and only _now_ have I gotten around to adding support for the Baseboard in Migen :).

This PR is noninvasive, but I did run into an issue wrt constraints: Baseboard has a PMOD connector, and normally in Migen I see this provided as a connector with a user needs to modify w/ `add_extension`. In the case of Mercury, whose GPIO pins can be used standalone or with the Baseboard, the PMOD connector overlaps with the GPIO connector, and Migen is unable to detect a pin/resource conflict if I attempt to use both buses (via `add_extension`) at the same time. Of course, the backend will error out when trying to synthesize the design, but is this error considered acceptable? Should I fix it now, or wait until we flesh out #82?
