### PR TITLE
build/platforms/de0nano: Fix incorrect sw1 pin assignment: T9->T8

### DIFF
--- a/migen/build/platforms/de0nano.py
+++ b/migen/build/platforms/de0nano.py
@@ -22,7 +22,7 @@ _io = [
     ("key", 1, Pins("E1"), IOStandard("3.3-V LVTTL")),
 
     ("sw", 0, Pins("M1"), IOStandard("3.3-V LVTTL")),
-    ("sw", 1, Pins("T9"), IOStandard("3.3-V LVTTL")),
+    ("sw", 1, Pins("T8"), IOStandard("3.3-V LVTTL")),
     ("sw", 2, Pins("B9"), IOStandard("3.3-V LVTTL")),
     ("sw", 3, Pins("M15"), IOStandard("3.3-V LVTTL")),
 


### PR DESCRIPTION
This was incorrectly listed as T9 but should be T8. See pg14 of the user manual, ftp://ftp.altera.com/up/pub/Intel_Material/Boards/DE0-Nano/DE0_Nano_User_Manual.pdf