### PR TITLE
fix data output changing while not reading when fifo is full in non-fwft mode

### DIFF
--- a/migen/genlib/fifo.py
+++ b/migen/genlib/fifo.py
@@ -1,6 +1,6 @@
 from migen.fhdl.structure import *
 from migen.fhdl.module import Module
-from migen.fhdl.specials import Memory
+from migen.fhdl.specials import Memory, READ_FIRST, WRITE_FIRST, NO_CHANGE
 from migen.fhdl.bitcontainer import log2_int
 from migen.fhdl.decorators import ClockDomainsRenamer
 from migen.genlib.cdc import MultiReg, GrayCounter
@@ -89,7 +89,7 @@ class SyncFIFO(Module, _FIFOInterface):
         storage = Memory(self.width, depth)
         self.specials += storage
 
-        wrport = storage.get_port(write_capable=True)
+        wrport = storage.get_port(write_capable=True, mode=READ_FIRST)
         self.specials += wrport
         self.comb += [
             If(self.replace,
@@ -106,7 +106,7 @@ class SyncFIFO(Module, _FIFOInterface):
         do_read = Signal()
         self.comb += do_read.eq(self.readable & self.re)
 
-        rdport = storage.get_port(async_read=fwft, has_re=not fwft)
+        rdport = storage.get_port(async_read=fwft, has_re=not fwft, mode=READ_FIRST)
         self.specials += rdport
         self.comb += [
             rdport.adr.eq(consume),

--- a/migen/genlib/fifo.py
+++ b/migen/genlib/fifo.py
@@ -1,6 +1,6 @@
 from migen.fhdl.structure import *
 from migen.fhdl.module import Module
-from migen.fhdl.specials import Memory, READ_FIRST, WRITE_FIRST, NO_CHANGE
+from migen.fhdl.specials import Memory, READ_FIRST
 from migen.fhdl.bitcontainer import log2_int
 from migen.fhdl.decorators import ClockDomainsRenamer
 from migen.genlib.cdc import MultiReg, GrayCounter


### PR DESCRIPTION
When using SyncFIFO with fwft=False, the memory location corresponding to the last data read is vacated. When the fifo reaches capacity, the data is overwritten and the output changes to the last data written after 1 cycle.

Change the memory mode to register the output data (rather than the output address) so data read remains valid even when fifo is full.