### PR TITLE
make memory simulation behavior for read ports same as emitted verilog

### DIFF
--- a/migen/fhdl/simplify.py
+++ b/migen/fhdl/simplify.py
@@ -87,7 +87,7 @@ class MemoryToArray(ModuleTransformer):
                 if port.async_read:
                     f.comb.append(port.dat_r.eq(storage[port.adr]))
                 else:
-                    if port.mode == WRITE_FIRST and port.we is not None:
+                    if port.mode == WRITE_FIRST:
                         adr_reg = Signal.like(port.adr)
                         rd_stmt = adr_reg.eq(port.adr)
                         f.comb.append(port.dat_r.eq(storage[adr_reg]))


### PR DESCRIPTION
Migen simulation behavior of read-only ports in `WRITE_FIRST` (default) mode does not correspond to the behavior of the emitted verilog translation; instead they behave like `READ_FIRST` ports.

In case of address collision, or (if a read enable signal is used on the read port) in case of later modification of the read memory location, the output value changes in synthesis but does not change in simulation.

This makes sure that read-only ports in `WRITE_FIRST` mode fall into the same case as they do in synthesis.

The simulation code for `NO_CHANGE` mode uses the `port.we` signal and reduces to the else condition when the port is read-only, so no change needed there.