### PR TITLE
fhdl/verilog: Don't emit constants larger than bit width for signed constants

### DIFF
--- a/migen/fhdl/verilog.py
+++ b/migen/fhdl/verilog.py
@@ -44,8 +44,8 @@ def _printsig(ns, s):
 
 def _printconstant(node):
     if node.signed:
-        return (str(node.nbits) + "'sd" + str(2**node.nbits + node.value),
-                True)
+        val = node.value if node.value >= 0 else 2**node.nbits + node.value
+        return (str(node.nbits) + "'sd" + str(val), True)
     else:
         return str(node.nbits) + "'d" + str(node.value), False
 


### PR DESCRIPTION
Currently the emitted verilog for signed constants always has 2**nbits added, which means for nonnegative values it will exceed the maximum value for its bit width. Since this just truncates it's not a problem, but it leads to thousands of pointless warnings in Quartus.

Not sure if you care especially about trying to quiet unnecessary warnings but it's a quick change to do so.