### PR TITLE
build: quartus: prevent conversion to RBF when no SOF is generated

### DIFF
--- a/migen/build/altera/quartus.py
+++ b/migen/build/altera/quartus.py
@@ -100,7 +100,10 @@ quartus_map --read_settings_files=on --write_settings_files=off {build_name} -c 
 quartus_fit --read_settings_files=off --write_settings_files=off {build_name} -c {build_name}
 quartus_asm --read_settings_files=off --write_settings_files=off {build_name} -c {build_name}
 quartus_sta {build_name} -c {build_name}
-quartus_cpf -c {build_name}.sof {build_name}.rbf
+if [ -f "{build_name}.sof" ]
+then
+    quartus_cpf -c {build_name}.sof {build_name}.rbf
+fi
 
 """.format(build_name=build_name)  # noqa
     build_script_file = "build_" + build_name + ".sh"


### PR DESCRIPTION
When targeting CPLD devices, Quartus generates the bitstream as a POF
file instead of SOF. It is not necessary to convert it to RBF bitstream
format in that case.