### PR TITLE
Ensure Memory that has a port with async_read=True is actually implemented as distributed ram

### DIFF
--- a/migen/fhdl/specials.py
+++ b/migen/fhdl/specials.py
@@ -278,6 +278,11 @@ class Memory(Special):
                 return verilog_printexpr(ns, e)[0]
         adrbits = bits_for(memory.depth-1)
 
+        for port in memory.ports:
+            if port.async_read:
+                r += "(* ram_style = \"distributed\" *) "
+                break
+
         r += "reg [" + str(memory.width-1) + ":0] " \
             + gn(memory) \
             + "[0:" + str(memory.depth-1) + "];\n"


### PR DESCRIPTION
Sometimes, when declaring a large memory with async_read=True, it gets placed in BRAM anyway. Most notably, when instantiating a large SyncFIFO. This is because the read address comes directly from a register, so it gets interpreted as the address register of a BRAM in write_first mode.

However, correct behavior of SyncFIFO depends on the address collision behavior of DRAM. The 'undefined' behavior of Xilinx BRAM in write_first mode is, in practice, the wrong behavior.

Since this unexpected size-dependent change of behavior is most likely undesirable in many cases where the user asks for an asynchronous read port, this patch adds a "ram_style = distributed" attribute to any memory that has one, to force it to be implemented in DRAM.

Unfortunately, "ram_style = distributed" is a Xilinx-only attribute, so as is this patch breaks Altera compatibility. There is currently nothing that specifies the platform in this context (and I'm not using platform in the first place), so this needs some big-picture rethinking of how to specify and hand down "is this for altera or xilinx" from verilog.convert().