### PR TITLE
platforms/tinyfpga_b: Add default serial mapping.

### DIFF
--- a/migen/build/platforms/tinyfpga_b.py
+++ b/migen/build/platforms/tinyfpga_b.py
@@ -28,6 +28,16 @@ _connectors = [
 ]
 
 
+# Default peripherals
+serial = [
+    ("serial", 0,
+        Subsignal("tx", Pins("GPIO:0")),
+        Subsignal("rx", Pins("GPIO:1")),
+        IOStandard("LVCMOS33")
+    )
+]
+
+
 class Platform(LatticePlatform):
     default_clk_name = "clk16"
     default_clk_period = 62.5


### PR DESCRIPTION
Another PR for [feature-parity with litex](https://github.com/enjoy-digital/litex/pull/65). To be fair, however, I should've provided this during the initial PR to add this platform. If misoc ever gets a USB CDC core (which AFAIK doesn't take up even a quarter of an ICE40 8K), we can probably get rid of this and users can use that instead.