### PR TITLE
build/platforms: Add tinyfpga_a platform.

### DIFF
--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -95,14 +95,10 @@ class OschRouting(Module):
 
 class Platform(LatticePlatform):
     default_clk_name = "osch_clk"
-    default_clk_period = 1000.0/15.65
-    osch_clk_period = 1000.0/15.65
-    # osch_clk_period is the variable used to set the OSCH period.
-    # If default_clk_name == "osch_clk", default_clk_period should _also_ be
-    # set to osch_clk_period for consistency with the rest of Migen,
-    # which may look for a class variable called default_clk_name.
+    default_clk_period = 1000.0/15.6
 
     def __init__(self):
+        self.osch_clk_period = 1000.0/15.65
         self.osch_routing = OschRouting()    # Internal oscillator routing.
         # Routed during self.do_finalize().
         LatticePlatform.__init__(self, "LCMXO2-1200HC-4SG32C", [],
@@ -147,6 +143,16 @@ class Platform(LatticePlatform):
         # Handle cases where OSCH is either not used or not default.
         if self.default_clk_name != "osch_clk":
             GenericPlatform.do_finalize(self, f, *args, **kwargs)
+
+    def set_osch_period(self, period):
+        # osch_clk_period is the variable used to set the OSCH period.
+        # If default_clk_name == "osch_clk", default_clk_period should _also_
+        # be set to osch_clk_period for consistency with the rest of Migen,
+        # which may look for a class variable called default_clk_name.
+        self.osch_clk_period = period
+
+        if self.default_clk_name == "osch_clk":
+            self.default_clk_period = period
 
     def add_internal_clock_constraint(self, clk, period):
         # Normally clocks are routed from I/O pins and are thus treated as

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -32,7 +32,7 @@ class MachClock(Module):
     # Diamond will complain that the frequency of the oscillator doesn't match
     # if it doesn't match one of the below frequencies. Since we tend to deal
     # with periods in nanoseconds, choose the closest frequency (in MHz)
-    # without going over. These numbers were extracted from
+    # within +/-5%. These numbers were extracted from
     # "MachXO2 sysCLOCK PLL Design and Usage Guide"
     supported_freqs = [
         2.08, 2.15, 2.22, 2.29, 2.38, 2.46, 2.56, 2.66, 2.77, 2.89,
@@ -52,10 +52,31 @@ class MachClock(Module):
                                   )
 
     def nearest_freq(self, period):
-        i = bisect.bisect_right(self.supported_freqs, 1000.0/period)
-        if i:
-            return self.supported_freqs[i-1]
-        raise ValueError("Clock period out of range for internal oscillator.")
+        target_freq = 1000.0/period
+
+        # A None match is defined to not be in range. Handles special cases
+        # described below.
+        def in_range(actual, err=0.05):
+            return abs((target_freq - actual)/target_freq) <= err if actual else False
+
+        # Agreed-upon algorithm:
+        # https://github.com/m-labs/migen/pull/111#discussion_r189687411
+        i = bisect.bisect_right(self.supported_freqs, target_freq)
+
+        # Special case: desired freq was < 2.08, but could still within +5%
+        lo_match = self.supported_freqs[i-1] if i else None
+
+        # Special case: desired freq was > 133.00, but could still within -5%
+        hi_match = self.supported_freqs[i] if i < len(self.supported_freqs) else None
+
+        if in_range(lo_match):
+            selected_freq = lo_match
+        elif in_range(hi_match):
+            selected_freq = hi_match
+        else:
+            raise ValueError("Clock period out of range (-/+5%) for internal oscillator.")
+
+        return selected_freq
 
 
 class Platform(LatticePlatform):

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -55,7 +55,7 @@ class MachClock(Module):
         i = bisect.bisect_right(self.supported_freqs, 1000.0/period)
         if i:
             return self.supported_freqs[i-1]
-        raise ValueError
+        raise ValueError("Clock period out of range for internal oscillator.")
 
 
 class Platform(LatticePlatform):
@@ -75,7 +75,7 @@ class Platform(LatticePlatform):
     def request(self, *args, **kwargs):
         try:
             sig = GenericPlatform.request(self, *args, **kwargs)
-        except:
+        except ConstraintError:
             # Do not add to self.constraint_manager.matched because we
             # don't want this signal to become part of the UCF.
             if (args[0] == "osch_clk") and not self.osch_used:

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -45,8 +45,9 @@ class MachClock(Module):
     ]
 
     def __init__(self, period, out):
+        freq_str = "{:.2f}".format(self.nearest_freq(period))
         self.specials += Instance("OSCH",
-                                  p_NOM_FREQ=str(self.nearest_freq(period)),
+                                  p_NOM_FREQ=freq_str,
                                   i_STDBY=C(0),
                                   o_OSC=out
                                   )

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -16,7 +16,7 @@ _connectors = [
 # Default peripherals.
 # Only on AX.
 led = [
-    ("user_led", 0, Pins("GPIO:0"))
+    ("user_led", 0, Pins("GPIO:0"), IOStandard("LVCMOS33"))
 ]
 
 serial = [
@@ -146,6 +146,10 @@ class Platform(LatticePlatform):
         # And lastly, add the oscillator routing so the correct primitive
         # is instantiated.
         f += self.osch_routing.get_fragment()
+
+        # Handle cases where OSCH is either not used or not default.
+        if self.default_clk_name != "osch_clk":
+            GenericPlatform.do_finalize(self, f, *args, **kwargs)
 
     def add_internal_clock_constraint(self, clk, period):
         # Normally clocks are routed from I/O pins and are thus treated as

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -4,9 +4,6 @@ from migen import *
 from migen.build.generic_platform import *
 from migen.build.lattice import LatticePlatform
 
-_io = [
-]
-
 _connectors = [
     # Pins 1-22
     ("GPIO", "13 14 16 17 20 21 23 25 26 27 28 4 5 8 9 10 11 12"),
@@ -108,7 +105,7 @@ class Platform(LatticePlatform):
     def __init__(self):
         self.osch_routing = OschRouting()    # Internal oscillator routing.
         # Routed during self.do_finalize().
-        LatticePlatform.__init__(self, "LCMXO2-1200HC-4SG32C", _io,
+        LatticePlatform.__init__(self, "LCMXO2-1200HC-4SG32C", [],
                                  _connectors, toolchain="diamond")
 
     # MachXO2 has an internal clock, which is not exposed as an I/O.

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -1,0 +1,99 @@
+import bisect
+
+from migen import *
+from migen.build.generic_platform import *
+from migen.build.lattice import LatticePlatform
+
+_io = [
+]
+
+_connectors = [
+    # Pins 1-22
+    ("GPIO", "13 14 16 17 20 21 23 25 26 27 28 4 5 8 9 10 11 12"),
+]
+
+
+# Default peripherals.
+# Only on AX.
+led = [
+    ("user_led", 0, Pins("GPIO:0"))
+]
+
+serial = [
+    ("serial", 0,
+        Subsignal("tx", Pins("GPIO:2")),
+        Subsignal("rx", Pins("GPIO:3")),
+        IOStandard("LVCMOS33")
+     )
+]
+
+
+class MachClock(Module):
+    # Diamond will complain that the frequency of the oscillator doesn't match
+    # if it doesn't match one of the below frequencies. Since we tend to deal
+    # with periods in nanoseconds, choose the closest frequency (in MHz)
+    # without going over. These numbers were extracted from
+    # "MachXO2 sysCLOCK PLL Design and Usage Guide"
+    supported_freqs = [
+        2.08, 2.15, 2.22, 2.29, 2.38, 2.46, 2.56, 2.66, 2.77, 2.89,
+        3.02, 3.17, 3.33, 3.50, 3.69, 3.91, 4.16, 4.29, 4.43, 4.59,
+        4.75, 4.93, 5.12, 5.32, 5.54, 5.78, 6.05, 6.33, 6.65, 7.00,
+        7.39, 7.82, 8.31, 8.58, 8.87, 9.17, 9.50, 9.85, 10.23, 10.64,
+        11.08, 11.57, 12.09, 12.67, 13.30, 14.00, 14.78, 15.65, 15.65, 16.63,
+        17.73, 19.00, 20.46, 22.17, 24.18, 26.60, 29.56, 33.25, 38.00, 44.33,
+        53.20, 66.50, 88.67, 133.00
+    ]
+
+    def __init__(self, period, out):
+        self.specials += Instance("OSCH",
+                                  p_NOM_FREQ=str(self.nearest_freq(period)),
+                                  i_STDBY=C(0),
+                                  o_OSC=out
+                                  )
+
+    def nearest_freq(self, period):
+        i = bisect.bisect_right(self.supported_freqs, 1000.0/period)
+        if i:
+            return self.supported_freqs[i-1]
+        raise ValueError
+
+
+class Platform(LatticePlatform):
+    default_clk_name = "osch_clk"
+    default_clk_period = 62.5
+
+    def __init__(self):
+        self.osch_used = False  # There may be > 1 osch,
+        # but there's only one default clk.
+        self.osch_routing = Module()    # Internal oscillator routing.
+        # Routed during self.do_finalize().
+        LatticePlatform.__init__(self, "LCMXO2-1200HC-4SG32C", _io,
+                                 _connectors, toolchain="diamond")
+
+    # MachXO2 has an internal clock, which is not exposed as an I/O.
+    # To get access to it, we handle a request for the clock specially.
+    def request(self, *args, **kwargs):
+        try:
+            sig = GenericPlatform.request(self, *args, **kwargs)
+        except:
+            # Do not add to self.constraint_manager.matched because we
+            # don't want this signal to become part of the UCF.
+            if (args[0] == "osch_clk") and not self.osch_used:
+                self.mach_clk_sig = Signal(name_override=args[0])
+                self.osch_routing.submodules += \
+                    MachClock(self.default_clk_period, self.mach_clk_sig)
+                sig = self.mach_clk_sig
+                self.osch_used = True
+            else:
+                raise
+        return sig
+
+    def do_finalize(self, f, *args, **kwargs):
+        # Still add clock to period constraints even though it is not a pin.
+        if self.osch_used and hasattr(self, "default_clk_period"):
+            self.add_period_constraint(self.mach_clk_sig,
+                                       self.default_clk_period)
+
+        # And lastly, add the oscillator routing so the correct primitive
+        # is instantiated.
+        f += self.osch_routing.get_fragment()

--- a/migen/build/platforms/tinyfpga_a.py
+++ b/migen/build/platforms/tinyfpga_a.py
@@ -99,6 +99,11 @@ class OschRouting(Module):
 class Platform(LatticePlatform):
     default_clk_name = "osch_clk"
     default_clk_period = 1000.0/15.65
+    osch_clk_period = 1000.0/15.65
+    # osch_clk_period is the variable used to set the OSCH period.
+    # If default_clk_name == "osch_clk", default_clk_period should _also_ be
+    # set to osch_clk_period for consistency with the rest of Migen,
+    # which may look for a class variable called default_clk_name.
 
     def __init__(self):
         self.osch_routing = OschRouting()    # Internal oscillator routing.
@@ -116,9 +121,7 @@ class Platform(LatticePlatform):
                 # Do not add to self.constraint_manager.matched because we
                 # don't want this signal to become part of the UCF.
                 sig = self.osch_routing.mk_clk("osch_clk",
-                                               self.default_clk_period)
-            else:
-                raise
+                                               self.osch_clk_period)
         return sig
 
     def do_finalize(self, f, *args, **kwargs):
@@ -134,9 +137,9 @@ class Platform(LatticePlatform):
         # due to the combination of oscillator tolerance and the frequency
         # selection algorithm. If the lower closest frequency was chosen, the
         # constraint will be up to 5% higher than the desired frequency.
-        if self.osch_routing.osch_used and hasattr(self, "default_clk_period"):
+        if self.osch_routing.osch_used and hasattr(self, "osch_clk_period"):
             adjusted_freq = 1.05 * \
-                self.osch_routing.mclk.nearest_freq(self.default_clk_period)
+                self.osch_routing.mclk.nearest_freq(self.osch_clk_period)
             self.add_internal_clock_constraint(self.osch_routing.mach_clk_sig,
                                                1000.0/adjusted_freq)
 


### PR DESCRIPTION
This pull request adds support for the (non-open) MachXO2-based `tinyfpga` A-series.

I don't expect this PR to be accepted as-is. MachXO2 is an odd FPGA in that it has an internal oscillator, and the board designer (cc: @tinyfpga) expects you to use the `OSCH` primitive to instantiate a default clock. Since this resource isn't provided by a pin, but each board is expected to provide a default clock, I improvised (read: created a hack) and created a subclassed `request` method to specifically handle the system clock without `migen.build.generic_platform.constraint_manager` allocating a pin. This way, methods of `GenericPlatform` that depend on `request` (such as `finalize`) still work, as intended without `resolve_signals` creating a fake pin constraint for a clock which is generated internally.

This works, but... I don't like this. I would prefer something nicer to deal with this special case of internally generated clock without making `migen.build.generic_platform.constraint_manager` manage every single "hard IP"/primitive provided by a given FPGA. Any suggestions?