### PR TITLE
Sayma AMC: add SYSCLK1_300

### DIFF
--- a/migen/build/platforms/sinara/sayma_amc.py
+++ b/migen/build/platforms/sinara/sayma_amc.py
@@ -287,6 +287,14 @@ _io = [
         Subsignal("n", Pins("B11")),
         IOStandard("LVDS"), Misc("DIFF_TERM_ADV=TERM_100")
     ),
+
+    # has 100R external termination resistor
+    ("sysclk1_300", 0,
+        Subsignal("p", Pins("F18")),
+        Subsignal("n", Pins("F17")),
+        IOStandard("DIFF_SSTL15_DCI"), Misc("OUTPUT_IMPEDANCE=RDRV_40_40")
+    ),
+
 ]
 
 


### PR DESCRIPTION
This is useful as a high-speed, unbuffered IO port for debugging.