### PR TITLE
give context when an exception is raised while evaluating a generator yield statement in simulation

### DIFF
--- a/migen/sim/core.py
+++ b/migen/sim/core.py
@@ -359,7 +359,16 @@ class Simulator:
                             raise ValueError("Unknown simulator command: '{}'"
                                              .format(request))
                     else:
-                        reply = self._evalexec_nested_lists(request)
+                        try:
+                            reply = self._evalexec_nested_lists(request)
+                        except Exception as e:
+                            tb = inspect.getframeinfo(generator.gi_frame)
+                            print("While evaluating the following generator, an error occurred:")
+                            print("  File {}, line {}, in {}".format(tb.filename, tb.lineno, tb.function))
+                            for c in tb.code_context:
+                                print("    ", c.lstrip())
+                            raise
+
                 except StopIteration:
                     exhausted.append(generator)
                     break


### PR DESCRIPTION
If an exception occurs during simulation, it is difficult to find out what user code provoked it from the traceback, which only shows the simulator code. This commit adds a print of the generator's current code location if the exception is raised while the simulator is evaluating a statement yielded from a generator. For example, trying to access a non-existent memory location will show the following:

```
While evaluating the following generator, an error occurred:
  File mem_out_of_range_test.py, line 36, in gen_test
     print((yield self.mem[adr]))

Traceback (most recent call last):
  File "mem_out_of_range_test.py", line 65, in <module>
    main()
  File "mem_out_of_range_test.py", line 50, in main
    run_simulation(dut, [dut.gen_test()], vcd_name="mem_out_of_range_test.vcd")
  File "/home/nengel/migen2/migen/sim/core.py", line 407, in run_simulation
    s.run()
  File "/home/nengel/migen2/migen/sim/core.py", line 396, in run
    self._process_generators(cd)
  File "/home/nengel/migen2/migen/sim/core.py", line 363, in _process_generators
    reply = self._evalexec_nested_lists(request)
  File "/home/nengel/migen2/migen/sim/core.py", line 337, in _evalexec_nested_lists
    return self.evaluator.eval(x)
  File "/home/nengel/migen2/migen/sim/core.py", line 158, in eval
    return self.eval(array[self.eval(node.index, postcommit)], postcommit)
  File "/home/nengel/migen2/migen/fhdl/structure.py", line 680, in __getitem__
    return list.__getitem__(self, key)
IndexError: list index out of range
```
