### PR TITLE
Fix issue where BusSynchronizer fails when iclock << oclock

### DIFF
--- a/migen/genlib/cdc.py
+++ b/migen/genlib/cdc.py
@@ -107,7 +107,7 @@ class BusSynchronizer(Module):
             self.comb += [
                 self._timeout.wait.eq(~self._ping.i),
                 self._ping.i.eq(starter | self._pong.o | self._timeout.done),
-                self._pong.i.eq(self._ping.i)
+                self._pong.i.eq(self._ping.o)
             ]
 
             ibuffer = Signal(width, reset_less=True)


### PR DESCRIPTION
I believe this fixes issue #143 