### PR TITLE
class TSTriple: width is the width of the base signal

### DIFF
--- a/migen/fhdl/specials.py
+++ b/migen/fhdl/specials.py
@@ -78,6 +78,9 @@ class TSTriple:
     def get_tristate(self, target):
         return Tristate(target, self.o, self.oe, self.i)
 
+    def __len__(self):
+        return len(self.o)
+
 
 class Instance(Special):
     class _IO:


### PR DESCRIPTION
This PR is inspired by the spi2 core from MiSoC. That calls len() on cs_n so we need to support len on TSTriple if cs_n may be a TSTriple object.
