### PR TITLE
class TSTriple: give subsignals a proper name

### DIFF
--- a/migen/fhdl/specials.py
+++ b/migen/fhdl/specials.py
@@ -70,10 +70,11 @@ class Tristate(Special):
 
 
 class TSTriple:
-    def __init__(self, bits_sign=None, min=None, max=None, reset_o=0, reset_oe=0, reset_i=0):
-        self.o = Signal(bits_sign, min=min, max=max, reset=reset_o)
-        self.oe = Signal(reset=reset_oe)
-        self.i = Signal(bits_sign, min=min, max=max, reset=reset_i)
+    def __init__(self, bits_sign=None, min=None, max=None, reset_o=0, reset_oe=0, reset_i=0, name=None):
+        self.name = name = get_obj_var_name(name)
+        self.o = Signal(bits_sign, min=min, max=max, reset=reset_o, name_override=name+"_o")
+        self.oe = Signal(reset=reset_oe, name_override=name+"_oe")
+        self.i = Signal(bits_sign, min=min, max=max, reset=reset_i, name_override=name+"_i")
 
     def get_tristate(self, target):
         return Tristate(target, self.o, self.oe, self.i)


### PR DESCRIPTION
Don't understand all intricacies of `name` vs `name_override` yet. So comment if it should be changed. Tried to mimick how it's done for other classes.
It Works For Me(tm)
