### PR TITLE
Update list of valid packages for iCE40-HX8K

### DIFF
--- a/migen/build/lattice/icestorm.py
+++ b/migen/build/lattice/icestorm.py
@@ -190,7 +190,9 @@ class LatticeIceStormToolchain:
             "hx1k": ["vq100", "cb132", "tq144"],
             "lp8k": ["cm81", "cm81:4k", "cm121", "cm121:4k", "cm225",
                      "cm225:4k"],
-            "hx8k": ["cb132", "cb132:4k", "tq144:4k", "cm225", "ct256"],
+            "hx8k": ["bg121", "bg121:4k", "cb132", "cb132:4k", "cm121",
+                     "cm121:4k", "cm225", "cm225:4k", "cm81", "cm81:4k",
+                     "ct256", "tq144:4k"],
             "up5k": ["sg48"],
         }
 


### PR DESCRIPTION
It looks like the list has become out of date compared to the latest `chipdb-8k.txt` from icestorm. I haven't tested generation for all these packages but have for at least the `bg121` which didn't work before this patch and does afterwards.