### PR TITLE
fhdl/tracer: support Python 3.7

### DIFF
--- a/migen/fhdl/tracer.py
+++ b/migen/fhdl/tracer.py
@@ -15,8 +15,11 @@ _call_opcodes = {
 if version_info[1] < 6:
     _call_opcodes["CALL_FUNCTION_VAR"] = 3
     _call_opcodes["CALL_FUNCTION_VAR_KW"] = 3
+elif version_info[1] < 7:
+    _call_opcodes["CALL_FUNCTION_EX"] = 2
 else:
     _call_opcodes["CALL_FUNCTION_EX"] = 2
+    _call_opcodes["CALL_METHOD"] = 2
 
 _load_build_opcodes = {
     "LOAD_GLOBAL" : _bytecode_length_version_guard(3),


### PR DESCRIPTION
Add support for new opcode CALL_METHOD
https://docs.python.org/3/library/dis.html#opcode-CALL_METHOD

This makes the naming consistent between python 3.6 and 3.7