### PR TITLE
Fix `-vlgincdir` for xst.

### DIFF
--- a/migen/build/xilinx/ise.py
+++ b/migen/build/xilinx/ise.py
@@ -57,8 +57,11 @@ def _build_xst_files(device, sources, vincpaths, build_name, xst_opt):
 -ofn {build_name}.ngc
 -p {device}
 """.format(build_name=build_name, xst_opt=xst_opt, device=device)
-    for path in vincpaths:
-        xst_contents += "-vlgincdir " + tools.cygpath(path) + "\n"
+    if vincpaths:
+        xst_contents += "-vlgincdir {"
+        for path in vincpaths:
+            xst_contents += tools.cygpath(path) + " "
+        xst_contents += "}"
     tools.write_to_file(build_name + ".xst", xst_contents)
 
 


### PR DESCRIPTION
The command line is of the form;
```
-vlgincdir {"path1" "path2"}
```

Fixes the following error;
```
WARNING:Xst:3164 - Option "-vlgincdir" found multiple times in the command line. Only the first occurence is considered.
```