### PR TITLE
Updating Pins of de0nanosoc.py Platform file

### DIFF
--- a/migen/build/platforms/de0nanosoc.py
+++ b/migen/build/platforms/de0nanosoc.py
@@ -74,7 +74,7 @@ _io = [
             Subsignal("tx_data", Pins("A16 J14 A15 D17")),
             Subsignal("rx_dv", Pins("J13")),
             Subsignal("rx_data", Pins("A14 A11 C15 A9")),
-            Subsignal("reset_n", Pins("B14")),
+            Subsignal("reset_n", Pins("B4")),
             Subsignal("mdio", Pins("E16")),
             Subsignal("mdc", Pins("A13")),
             Subsignal("int_n", Pins("B14")),


### PR DESCRIPTION
The eth_reset_n and eth_int_n pins were set to the same value of B14. I'm updating the pin of eth_reset_n to B4 as on the schematic. eth_int_n is correct.