### PR TITLE
migen: replace `collections` with `collections.abc` as necessary

### DIFF
--- a/migen/fhdl/module.py
+++ b/migen/fhdl/module.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from itertools import combinations
 
 from migen.util.misc import flat_iteration
@@ -15,7 +15,7 @@ class FinalizeError(Exception):
 
 
 def _flat_list(e):
-    if isinstance(e, collections.Iterable):
+    if isinstance(e, collections.abc.Iterable):
         return flat_iteration(e)
     else:
         return [e]

--- a/migen/fhdl/structure.py
+++ b/migen/fhdl/structure.py
@@ -1,4 +1,5 @@
 import builtins as _builtins
+import collections.abc as _collections_abc
 import collections as _collections
 import re as _re
 
@@ -481,7 +482,7 @@ class _Assign(_Statement):
 
 
 def _check_statement(s):
-    if isinstance(s, _collections.Iterable):
+    if isinstance(s, _collections_abc.Iterable):
         return all(_check_statement(ss) for ss in s)
     else:
         return isinstance(s, _Statement)
@@ -588,7 +589,7 @@ class Case(_Statement):
             if (not isinstance(k, Constant)
                     and not (isinstance(k, str) and k == "default")):
                 raise TypeError("Case object is not a Migen constant")
-            if not isinstance(v, _collections.Iterable):
+            if not isinstance(v, _collections_abc.Iterable):
                 v = [v]
             if not _check_statement(v):
                 raise TypeError("Not all objects for case {} "

--- a/migen/fhdl/verilog.py
+++ b/migen/fhdl/verilog.py
@@ -1,6 +1,6 @@
 from functools import partial
 from operator import itemgetter
-import collections
+import collections.abc
 import logging
 
 from migen.fhdl.structure import *
@@ -131,7 +131,7 @@ def _printnode(ns, at, level, node):
         else:
             assignment = " <= "
         return "\t"*level + _printexpr(ns, node.l)[0] + assignment + _printexpr(ns, node.r)[0] + ";\n"
-    elif isinstance(node, collections.Iterable):
+    elif isinstance(node, collections.abc.Iterable):
         return "".join(list(map(partial(_printnode, ns, at, level), node)))
     elif isinstance(node, If):
         r = "\t"*level + "if (" + _printexpr(ns, node.cond)[0] + ") begin\n"

--- a/migen/sim/core.py
+++ b/migen/sim/core.py
@@ -1,5 +1,5 @@
 import operator
-import collections
+import collections.abc
 import inspect
 from functools import wraps
 
@@ -227,7 +227,7 @@ class Evaluator:
                         break
                 if not found and "default" in s.cases:
                     self.execute(s.cases["default"])
-            elif isinstance(s, collections.Iterable):
+            elif isinstance(s, collections.abc.Iterable):
                 self.execute(s)
             elif isinstance(s, Display):
                 args = []
@@ -279,7 +279,7 @@ class Simulator:
         self.generators = dict()
         self.passive_generators = set()
         for k, v in generators.items():
-            if (isinstance(v, collections.Iterable)
+            if (isinstance(v, collections.abc.Iterable)
                     and not inspect.isgenerator(v)):
                 self.generators[k] = list(v)
             else:

--- a/migen/util/misc.py
+++ b/migen/util/misc.py
@@ -1,10 +1,10 @@
 from math import gcd
-import collections
+import collections.abc
 
 
 def flat_iteration(l):
     for element in l:
-        if isinstance(element, collections.Iterable):
+        if isinstance(element, collections.abc.Iterable):
             for element2 in flat_iteration(element):
                 yield element2
         else:


### PR DESCRIPTION
Python 3.7 deprecated some fields in `collections`, most notably
`collections.Iterable`.  When run under Python 3.7, the interpreter
emits deprecation warnings, and notes that it will stop working entirely
under Python 3.8.

This patch replaces instances of `collections` with `collections.abc` as
necessary.

This patch fixes issue #175 