### PR TITLE
Lattice iCE40: implement DifferentialInput

### DIFF
--- a/migen/build/lattice/common.py
+++ b/migen/build/lattice/common.py
@@ -135,8 +135,25 @@ class LatticeiCE40DifferentialOutput:
     def lower(dr):
         return LatticeiCE40DifferentialOutputImpl(dr.i, dr.o_p, dr.o_n)
 
+
+class LatticeiCE40DifferentialInputImpl(Module):
+    def __init__(self, i_p, i_n, o):
+        self.specials += Instance("SB_IO",
+                                  p_PIN_TYPE=C(0b000001, 6),  # simple input pin
+                                  p_IO_STANDARD="SB_LVDS_INPUT",
+                                  io_PACKAGE_PIN=i_n,
+                                  o_D_IN_0=o)
+
+
+class LatticeiCE40DifferentialInput:
+    @staticmethod
+    def lower(dr):
+        return LatticeiCE40DifferentialInputImpl(dr.i_p, dr.i_n, dr.o)
+
+
 lattice_ice40_special_overrides = {
     AsyncResetSynchronizer: LatticeiCE40AsyncResetSynchronizer,
     Tristate:               LatticeiCE40Tristate,
-    DifferentialOutput:     LatticeiCE40DifferentialOutput
+    DifferentialOutput:     LatticeiCE40DifferentialOutput,
+    DifferentialInput:      LatticeiCE40DifferentialInput,
 }


### PR DESCRIPTION
This patch is a basic implementation of `DifferentialInput` for Lattice iCE40 based on [TN1253](http://www.latticesemi.com/~/media/LatticeSemi/Documents/ApplicationNotes/UZ/UsingDifferentialIOLVDSSubLVDSiniCE40Devices.pdf).

Based on the discussion in #177, this is cumbersome to use with yosys/nextpnr because of the way the `SB_LVDS_INPUT` IO standard works. My understanding is that one needs to pass a dummy signal to `i_p` and make sure the corresponding `IOL_xA` resource is not requested / listed in the pcf. Is this correct? Is there an easy way to make the instantiation of `DifferentialInput` less error-prone?