### PR TITLE
Lattice iCE40: fix DifferentialInput polarity

### DIFF
--- a/migen/build/lattice/common.py
+++ b/migen/build/lattice/common.py
@@ -138,11 +138,13 @@ class LatticeiCE40DifferentialOutput:
 
 class LatticeiCE40DifferentialInputImpl(Module):
     def __init__(self, i_p, i_n, o):
+        o_n = Signal.like(o)
         self.specials += Instance("SB_IO",
                                   p_PIN_TYPE=C(0b000001, 6),  # simple input pin
                                   p_IO_STANDARD="SB_LVDS_INPUT",
                                   io_PACKAGE_PIN=i_n,
-                                  o_D_IN_0=o)
+                                  o_D_IN_0=o_n)
+        self.comb += o.eq(~o_n)
 
 
 class LatticeiCE40DifferentialInput:


### PR DESCRIPTION
This patch fixes the polarity of the `DifferentialInput` implementation for Lattice iCE40 platforms.

Although IMHO not very explicit in the docs (neither in [TN1253](http://www.latticesemi.com/~/media/LatticeSemi/Documents/ApplicationNotes/UZ/UsingDifferentialIOLVDSSubLVDSiniCE40Devices.pdf?document_id=47960) nor in the [technology library docs](http://www.latticesemi.com/~/media/LatticeSemi/Documents/TechnicalBriefs/SBTICETechnologyLibrary201504.pdf)), the output of `SB_IO` with `SB_LVDS_INPUT` IO standard is inverted. This however makes somehow sense since the `SB_IO` cell is passed the negative pin of the differential pair.

This behaviour was observed with nextpnr version YosysHQ/nextpnr@265fa1b and yosys version YosysHQ/yosys@ea8ac0aa.