### PR TITLE
Fix iCE40 DifferentialInput

### DIFF
--- a/migen/build/lattice/common.py
+++ b/migen/build/lattice/common.py
@@ -138,13 +138,11 @@ class LatticeiCE40DifferentialOutput:
 
 class LatticeiCE40DifferentialInputImpl(Module):
     def __init__(self, i_p, i_n, o):
-        o_n = Signal.like(o)
         self.specials += Instance("SB_IO",
                                   p_PIN_TYPE=C(0b000001, 6),  # simple input pin
                                   p_IO_STANDARD="SB_LVDS_INPUT",
                                   io_PACKAGE_PIN=i_n,
-                                  o_D_IN_0=o_n)
-        self.comb += o.eq(~o_n)
+                                  o_D_IN_0=o)
 
 
 class LatticeiCE40DifferentialInput:

--- a/migen/build/lattice/common.py
+++ b/migen/build/lattice/common.py
@@ -141,7 +141,7 @@ class LatticeiCE40DifferentialInputImpl(Module):
         self.specials += Instance("SB_IO",
                                   p_PIN_TYPE=C(0b000001, 6),  # simple input pin
                                   p_IO_STANDARD="SB_LVDS_INPUT",
-                                  io_PACKAGE_PIN=i_n,
+                                  io_PACKAGE_PIN=i_p,
                                   o_D_IN_0=o)
 
 

--- a/migen/build/lattice/common.py
+++ b/migen/build/lattice/common.py
@@ -136,6 +136,12 @@ class LatticeiCE40DifferentialOutput:
         return LatticeiCE40DifferentialOutputImpl(dr.i, dr.o_p, dr.o_n)
 
 
+# For iCE40 HX/LP devices, 'IO[Bank]_[No]B' is the positive side of the pair.
+# For iCE40 UP devices, 'IO[Bank]_[No]a' is the positive side of the pair.
+# The SB_IO primitive expects the 'B' pin for HX/LP devices
+# and the 'a' pin for UP devices.
+# The output of SB_IO has the polarity of the passed pin.
+# See https://github.com/m-labs/migen/pull/181
 class LatticeiCE40DifferentialInputImpl(Module):
     def __init__(self, i_p, i_n, o):
         self.specials += Instance("SB_IO",


### PR DESCRIPTION
This patch reverts e43cd74 because of the underlying confusion between B=positive and A=negative pins, see [#181 (comment)](https://github.com/m-labs/migen/pull/181#issuecomment-489200088).
Moreover, the positive signal should be passed to `SB_IO`.