### PR TITLE
altera/quartus: fix generated build script

### DIFF
--- a/migen/build/altera/quartus.py
+++ b/migen/build/altera/quartus.py
@@ -102,7 +102,8 @@ quartus_asm --read_settings_files=off --write_settings_files=off {build_name} -c
 quartus_sta {build_name} -c {build_name}"""
 
     if create_rbf:
-        build_script_contents +="""if [ -f "{build_name}.sof" ]
+        build_script_contents +="""
+if [ -f "{build_name}.sof" ]
 then
     quartus_cpf -c {build_name}.sof {build_name}.rbf
 fi


### PR DESCRIPTION
Generated script was lacking one newline, which caused bash error.