### PR TITLE
Include examples in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include tools/strace_tailor.sh
+graft examples


### PR DESCRIPTION
These are needed to run the tests which are included in the sdists