### PR TITLE
Add integer attributes

### DIFF
--- a/migen/fhdl/verilog.py
+++ b/migen/fhdl/verilog.py
@@ -201,7 +201,8 @@ def _printattr(attr, attr_translate):
         if not firsta:
             r += ", "
         firsta = False
-        r += attr_name + " = \"" + attr_value + "\""
+        const_expr = "\"" + attr_value + "\"" if not isinstance(attr_value, int) else str(attr_value)
+        r += attr_name + " = " + const_expr
     if r:
         r = "(* " + r + " *)"
     return r


### PR DESCRIPTION
This PR adds support for integer attributes in Verilog as discussed in #189.

I was hesitant of testing it for `str` instead of `int` (`if isinstance(attr_value, str)`) but was afraid of edge cases with people using non str values (I'm not even sure if other types can be concatenated to str).