### PR TITLE
xilinx/vivado: emit sorted sources for top.tcl

### DIFF
--- a/migen/build/xilinx/vivado.py
+++ b/migen/build/xilinx/vivado.py
@@ -92,7 +92,7 @@ class XilinxVivadoToolchain:
         tcl = []
         tcl.append("create_project -force -name {} -part {}".format(build_name, platform.device))
         tcl.append("set_property XPM_LIBRARIES {XPM_CDC XPM_MEMORY} [current_project]")
-        for filename, language, library in sources:
+        for filename, language, library in sorted(sources, key=lambda x: x[0]):
             filename_tcl = "{" + filename + "}"
             tcl.append("add_files " + filename_tcl)
             tcl.append("set_property library {} [get_files {}]"


### PR DESCRIPTION
A stable order helps reproducability of the generated bitstream source code. This fix helps avoiding unnecessary rebuilds.