### PR TITLE
generic_platform: add copy_sources(), remove verilog_include_paths

### DIFF
--- a/migen/build/altera/quartus.py
+++ b/migen/build/altera/quartus.py
@@ -68,7 +68,7 @@ def _build_qsf(named_sc, named_pc):
     return "\n".join(lines)
 
 
-def _build_files(device, sources, vincpaths, named_sc, named_pc, build_name):
+def _build_files(device, sources, named_sc, named_pc, build_name):
     lines = []
     for filename, language, library in sources:
         # Enforce use of SystemVerilog
@@ -81,10 +81,6 @@ def _build_files(device, sources, vincpaths, named_sc, named_pc, build_name):
                 lang=language.upper(),
                 path=filename.replace("\\", "/"),
                 lib=library))
-
-    for path in vincpaths:
-        lines.append("set_global_assignment -name SEARCH_PATH {}".format(
-            path.replace("\\", "/")))
 
     lines.append(_build_qsf(named_sc, named_pc))
     lines.append("set_global_assignment -name DEVICE {}".format(device))
@@ -137,7 +133,6 @@ class AlteraQuartusToolchain:
         sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
         _build_files(platform.device,
                      sources,
-                     platform.verilog_include_paths,
                      named_sc,
                      named_pc,
                      build_name)

--- a/migen/build/altera/quartus.py
+++ b/migen/build/altera/quartus.py
@@ -134,7 +134,7 @@ class AlteraQuartusToolchain:
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_file = build_name + ".v"
         v_output.write(v_file)
-        sources = platform.sources | {(v_file, "verilog", "work")}
+        sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
         _build_files(platform.device,
                      sources,
                      platform.verilog_include_paths,

--- a/migen/build/generic_programmer.py
+++ b/migen/build/generic_programmer.py
@@ -16,7 +16,7 @@ class GenericProgrammer:
     def find_flash_proxy(self):
         for d in self.flash_proxy_dirs:
             fulldir = os.path.abspath(os.path.expanduser(d))
-            fullname = tools.cygpath(os.path.join(fulldir, self.flash_proxy_basename))
+            fullname = os.path.join(fulldir, self.flash_proxy_basename)
             if os.path.exists(fullname):
                 return fullname
         raise OSError("Failed to find flash proxy bitstream")

--- a/migen/build/lattice/diamond.py
+++ b/migen/build/lattice/diamond.py
@@ -49,11 +49,9 @@ def _build_lpf(named_sc, named_pc):
     return r
 
 
-def _build_files(device, sources, vincpaths, build_name):
+def _build_files(device, sources, build_name):
     tcl = []
     tcl.append("prj_project new -name \"{}\" -impl \"impl\" -dev {} -synthesis \"synplify\"".format(build_name, device))
-    for path in vincpaths:
-        tcl.append("prj_impl option {include path} {\"" + path + "\"}")
     for filename, language, library in sources:
         tcl.append("prj_src add \"" + filename + "\" -work " + library)
     tcl.append("prj_impl option top \"{}\"".format(build_name))
@@ -150,7 +148,7 @@ class LatticeDiamondToolchain:
         v_file = build_name + ".v"
         v_output.write(v_file)
         sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
-        _build_files(platform.device, sources, platform.verilog_include_paths, build_name)
+        _build_files(platform.device, sources, build_name)
 
         tools.write_to_file(build_name + ".lpf", _build_lpf(named_sc, named_pc))
 

--- a/migen/build/lattice/diamond.py
+++ b/migen/build/lattice/diamond.py
@@ -149,7 +149,7 @@ class LatticeDiamondToolchain:
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_file = build_name + ".v"
         v_output.write(v_file)
-        sources = platform.sources | {(v_file, "verilog", "work")}
+        sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
         _build_files(platform.device, sources, platform.verilog_include_paths, build_name)
 
         tools.write_to_file(build_name + ".lpf", _build_lpf(named_sc, named_pc))

--- a/migen/build/lattice/icestorm.py
+++ b/migen/build/lattice/icestorm.py
@@ -219,13 +219,9 @@ class LatticeIceStormToolchain:
 
     def gen_read_files(self, platform, main, build_dir):
         sources = platform.copy_sources(build_dir) | {(main, "verilog", "work")}
-        incflags = ""
         read_files = list()
-        for path in platform.verilog_include_paths:
-            incflags += " -I" + path
         for filename, language, library in sources:
-            read_files.append("read_{}{} {}".format(language,
-                                                    incflags,
+            read_files.append("read_{} {}".format(language,
                                                     filename))
         return "\n".join(read_files)
 

--- a/migen/build/lattice/icestorm.py
+++ b/migen/build/lattice/icestorm.py
@@ -142,7 +142,7 @@ class LatticeIceStormToolchain:
         else:
             chosen_yosys_template = self.yosys_template
         ys_contents = "\n".join(_.format(build_name=build_name,
-                                         read_files=self.gen_read_files(platform, v_file),
+                                         read_files=self.gen_read_files(platform, v_file, build_dir),
                                          synth_opts=synth_opts)
                                 for _ in chosen_yosys_template)
 
@@ -217,8 +217,8 @@ class LatticeIceStormToolchain:
     def get_size_string(self, series_size_str):
         return series_size_str[2:]
 
-    def gen_read_files(self, platform, main):
-        sources = platform.sources | {(main, "verilog", "work")}
+    def gen_read_files(self, platform, main, build_dir):
+        sources = platform.copy_sources(build_dir) | {(main, "verilog", "work")}
         incflags = ""
         read_files = list()
         for path in platform.verilog_include_paths:

--- a/migen/build/lattice/trellis.py
+++ b/migen/build/lattice/trellis.py
@@ -95,13 +95,10 @@ def _run_script(script):
 
 
 def yosys_import_sources(platform):
-    includes = ""
     reads = []
-    for path in platform.verilog_include_paths:
-        includes += " -I" + path
     for filename, language, library in platform.copy_sources(build_dir):
-        reads.append("read_{}{} {}".format(
-            language, includes, filename))
+        reads.append("read_{} {}".format(
+            language, filename))
     return "\n".join(reads)
 
 

--- a/migen/build/lattice/trellis.py
+++ b/migen/build/lattice/trellis.py
@@ -99,7 +99,7 @@ def yosys_import_sources(platform):
     reads = []
     for path in platform.verilog_include_paths:
         includes += " -I" + path
-    for filename, language, library in platform.sources:
+    for filename, language, library in platform.copy_sources(build_dir):
         reads.append("read_{}{} {}".format(
             language, includes, filename))
     return "\n".join(reads)

--- a/migen/build/tools.py
+++ b/migen/build/tools.py
@@ -40,35 +40,3 @@ def subprocess_call_filtered(command, rules, *, max_matches=1, **kwargs):
             for line in stdout:
                 print(sub_rules(line, rules, max_matches), end="")
         return proc.wait()
-
-
-if sys.platform == "cygwin":
-    cygwin1 = ctypes.CDLL("/usr/bin/cygwin1.dll")
-    cygwin_conv_path_proto = ctypes.CFUNCTYPE(
-        ctypes.c_ssize_t, # Return
-        ctypes.c_uint, # what
-        ctypes.c_void_p, # from
-        ctypes.c_void_p, # to
-        ctypes.c_size_t) # size
-    cygwin_conv_path = cygwin_conv_path_proto(("cygwin_conv_path", cygwin1),
-        ((1, "what"),
-        (1, "from"),
-        (1, "to"),
-        (1, "size")))
-
-
-    def cygpath_to_windows(path):
-        what = ctypes.c_uint(0) # CCP_POSIX_TO_WIN_A
-        fro = ctypes.c_char_p(path.encode('utf-8'))
-        to = ctypes.byref(ctypes.create_string_buffer(260))
-        size = ctypes.c_size_t(260)
-
-        cygwin_conv_path(what, fro, to, size)
-        return ctypes.cast(to, ctypes.c_char_p).value.decode('utf-8')
-
-    # Convert cygwin paths to Windows native paths. This is a noop otherwise.
-    def cygpath(p):
-        return cygpath_to_windows(p)
-else:
-    def cygpath(p):
-        return p

--- a/migen/build/xilinx/ise.py
+++ b/migen/build/xilinx/ise.py
@@ -172,7 +172,7 @@ class XilinxISEToolchain:
                 named_sc, named_pc = platform.resolve_signals(vns)
                 v_file = build_name + ".v"
                 v_output.write(v_file)
-                sources = platform.sources | {(v_file, "verilog", "work")}
+                sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
                 if mode in ("xst", "cpld"):
                     _build_xst_files(platform.device, sources, platform.verilog_include_paths, build_name, self.xst_opt)
                     isemode = mode

--- a/migen/build/xilinx/ise.py
+++ b/migen/build/xilinx/ise.py
@@ -47,7 +47,7 @@ def _build_ucf(named_sc, named_pc):
 def _build_xst_files(device, sources, build_name, xst_opt):
     prj_contents = ""
     for filename, language, library in sources:
-        prj_contents += language + " " + library + " " + tools.cygpath(filename) + "\n"
+        prj_contents += language + " " + library + " " + filename + "\n"
     tools.write_to_file(build_name + ".prj", prj_contents)
 
     xst_contents = """run

--- a/migen/build/xilinx/ise.py
+++ b/migen/build/xilinx/ise.py
@@ -44,7 +44,7 @@ def _build_ucf(named_sc, named_pc):
     return r
 
 
-def _build_xst_files(device, sources, vincpaths, build_name, xst_opt):
+def _build_xst_files(device, sources, build_name, xst_opt):
     prj_contents = ""
     for filename, language, library in sources:
         prj_contents += language + " " + library + " " + tools.cygpath(filename) + "\n"
@@ -57,19 +57,12 @@ def _build_xst_files(device, sources, vincpaths, build_name, xst_opt):
 -ofn {build_name}.ngc
 -p {device}
 """.format(build_name=build_name, xst_opt=xst_opt, device=device)
-    if vincpaths:
-        xst_contents += "-vlgincdir {"
-        for path in vincpaths:
-            xst_contents += tools.cygpath(path) + " "
-        xst_contents += "}"
     tools.write_to_file(build_name + ".xst", xst_contents)
 
 
-def _run_yosys(device, sources, vincpaths, build_name):
+def _run_yosys(device, sources, build_name):
     ys_contents = ""
     incflags = ""
-    for path in vincpaths:
-        incflags += " -I" + path
     for filename, language, library in sources:
         ys_contents += "read_{}{} {}\n".format(language, incflags, filename)
 
@@ -174,10 +167,10 @@ class XilinxISEToolchain:
                 v_output.write(v_file)
                 sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
                 if mode in ("xst", "cpld"):
-                    _build_xst_files(platform.device, sources, platform.verilog_include_paths, build_name, self.xst_opt)
+                    _build_xst_files(platform.device, sources, build_name, self.xst_opt)
                     isemode = mode
                 else:
-                    _run_yosys(platform.device, sources, platform.verilog_include_paths, build_name)
+                    _run_yosys(platform.device, sources, build_name)
                     isemode = "edif"
                     ngdbuild_opt += "-p " + platform.device
 

--- a/migen/build/xilinx/platform.py
+++ b/migen/build/xilinx/platform.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from migen.build.generic_platform import GenericPlatform
 from migen.build.xilinx import common, vivado, ise
@@ -23,6 +24,19 @@ class XilinxPlatform(GenericPlatform):
 
     def add_ip(self, filename):
         self.ips.add((os.path.abspath(filename)))
+
+    def copy_ips(self, build_dir, subdir="ip"):
+        copied_ips = set()
+
+        target = os.path.join(build_dir, subdir)
+        os.makedirs(target, exist_ok=True)
+        for filename in self.ips:
+            path = os.path.join(subdir, os.path.basename(filename))
+            dest = os.path.join(build_dir, path)
+            shutil.copyfile(filename, dest)
+            copied_ips.add(path)
+
+        return copied_ips
 
     def get_verilog(self, *args, special_overrides=dict(), **kwargs):
         so = dict(common.xilinx_special_overrides)

--- a/migen/build/xilinx/vivado.py
+++ b/migen/build/xilinx/vivado.py
@@ -211,7 +211,7 @@ class XilinxVivadoToolchain:
         v_output.write(v_file)
         sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
         edifs = platform.edifs
-        ips = platform.ips
+        ips = platform.copy_ips(build_dir)
         self._build_batch(platform, sources, edifs, ips, build_name, build_dir)
         tools.write_to_file(build_name + ".xdc", _build_xdc(named_sc, named_pc))
         if run:

--- a/migen/build/xilinx/vivado.py
+++ b/migen/build/xilinx/vivado.py
@@ -213,7 +213,7 @@ class XilinxVivadoToolchain:
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_file = build_name + ".v"
         v_output.write(v_file)
-        sources = platform.sources | {(v_file, "verilog", "work")}
+        sources = platform.copy_sources(build_dir) | {(v_file, "verilog", "work")}
         edifs = platform.edifs
         ips = platform.ips
         self._build_batch(platform, sources, edifs, ips, build_name)


### PR DESCRIPTION
Makes sources self-contained

So far, usage has been added to only the `XilinxVivadoToolchain` because that one is relevant for Artiq. Shall we copy_sources_to_cwd() in all Migen platforms for consistency?