### PR TITLE
xilinx: add DDRInput for Spartan6

### DIFF
--- a/migen/build/xilinx/common.py
+++ b/migen/build/xilinx/common.py
@@ -116,8 +116,6 @@ class XilinxDDROutputS6:
     def lower(dr):
         return XilinxDDROutputImplS6(dr.i1, dr.i2, dr.o, dr.clk)
 
-# Took this from litex/build/xilinx/common.py
-# migen doesn't include a DDR Input for S6
 class XilinxDDRInputImplS6(Module):
     def __init__(self, i, o1, o2, clk):
         self.specials += Instance("IDDR2",

--- a/migen/build/xilinx/common.py
+++ b/migen/build/xilinx/common.py
@@ -116,9 +116,35 @@ class XilinxDDROutputS6:
     def lower(dr):
         return XilinxDDROutputImplS6(dr.i1, dr.i2, dr.o, dr.clk)
 
+# Took this from litex/build/xilinx/common.py
+# migen doesn't include a DDR Input for S6
+class XilinxDDRInputImplS6(Module):
+    def __init__(self, i, o1, o2, clk):
+        self.specials += Instance("IDDR2",
+            p_DDR_ALIGNMENT = "C0",
+            p_INIT_Q0       = 0,
+            p_INIT_Q1       = 0,
+            p_SRTYPE        = "ASYNC",
+            i_C0 = clk,
+            i_C1 = ~clk,
+            i_CE = 1,
+            i_S  = 0,
+            i_R  = 0,
+            i_D  = i,
+            o_Q0 = o1,
+            o_Q1 = o2
+        )
+
+
+class XilinxDDRInputS6:
+    @staticmethod
+    def lower(dr):
+        return XilinxDDRInputImplS6(dr.i, dr.o1, dr.o2, dr.clk)
+
 
 xilinx_s6_special_overrides = {
-    DDROutput:              XilinxDDROutputS6
+    DDROutput: XilinxDDROutputS6,
+    DDRInput:  XilinxDDRInputS6,
 }
 
 


### PR DESCRIPTION
I wanted to use a DDRInput on my Spartan6 board but there isn't an implementation in migen (which seems a little odd as there is a DDROutput). I noticed that LiteX had one so I copied it across. I think the licensing is compatible.

Not sure if there is some policy for merging stuff from LiteX, looks like they have added quite a bit of stuff to buiid/.