### PR TITLE
fhdl/simplify: sort specials before init-ing new DUID objects

### DIFF
--- a/migen/fhdl/simplify.py
+++ b/migen/fhdl/simplify.py
@@ -12,7 +12,7 @@ class FullMemoryWE(ModuleTransformer):
     def transform_fragment(self, i, f):
         newspecials = set()
 
-        for orig in f.specials:
+        for orig in sorted(f.specials, key=lambda x: x.duid):
             if not isinstance(orig, Memory):
                 newspecials.add(orig)
                 continue
@@ -60,7 +60,7 @@ class MemoryToArray(ModuleTransformer):
         newspecials = set()
         processed_ports = set()
 
-        for mem in f.specials:
+        for mem in sorted(f.specials, key=lambda x: x.duid):
             if not isinstance(mem, Memory):
                 newspecials.add(mem)
                 continue
@@ -130,7 +130,7 @@ class SplitMemory(ModuleTransformer):
         old_specials, f.specials = f.specials, set()
         old_ports = set()
 
-        for old in old_specials:
+        for old in sorted(old_specials, key=lambda x: x.duid):
             if not isinstance(old, Memory):
                 f.specials.add(old)
                 continue


### PR DESCRIPTION
## Overview

This PR forces specials of fragments processed by the `ModuleTransformer` subclasses in `migen.fhdl.simplify` to be sorted, thus ensuring that the order of creating new DUIDs remains the same when unrelated parts of the module to be synthesised have been changed.

## Details

There are subclasses of `migen.fhdl.decorators.ModuleTransformer`, namely `FullMemoryWE`, `MemoryToArray` and `SplitMemory`, that are defined in `migen.fhdl.simplify`, and each of them iterate over a Python set `f.specials` to replace or remove existing `Special`s. 

Sometimes, new `Special`s are instantiated while iterating the set, creating new DUIDs in the process. However, since Python set is unordered, the same order of creating the DUIDs is not guaranteed if any other parts of the module content has changed. 

## Example

In ARTIQ, the decorator for `FullMemoryWE` is currently used by [`artiq.gateware.drtio.aux_controller`](https://github.com/m-labs/artiq/blob/master/artiq/gateware/drtio/aux_controller.py#L213). If the ARTIQ version has changed, since it is mandated by [`artiq/build_soc.py`](https://github.com/m-labs/artiq/blob/master/artiq/build_soc.py#L26-L44) that the version string is used for initialising a ROM primitive, the overall SoC module content would be changed. This change therefore would propagate to `FullMemoryWE`, leading to a totally different ordering of the replacement for `AuxController`'s SRAMs. This means a `diff` on the `top.v`s before and after changing the ARTIQ version string will not only show the ROM init value difference, but also the naming (numbering) and ordering of the `AuxController`s.

Now, this PR will eliminate such unrelated differences. This can be verified by running `diff` again, where it will only show the ROM init value difference.