### PR TITLE
[enh] use Misc() properties in trellis' PCF

### DIFF
--- a/migen/build/lattice/icestorm.py
+++ b/migen/build/lattice/icestorm.py
@@ -13,13 +13,25 @@ from migen.build.lattice import common
 
 
 def _build_pcf(named_sc, named_pc):
+    diamond2trellis_tr = {
+        "PULLUP_RESISTOR" : "-pullup_resistor",
+        "PULLUP" : "-pullup 1",
+    }
     r = ""
     for sig, pins, others, resname in named_sc:
+        misc = ""
+        for other in others:
+            if isinstance(other, Misc):
+                arg = other.misc
+                for diamond_arg in diamond2trellis_tr:
+                    if diamond_arg in arg:
+                        arg = arg.replace(diamond_arg, diamond2trellis_tr[diamond_arg]) 
+                misc += ' ' + arg
         if len(pins) > 1:
             for bit, pin in enumerate(pins):
-                r += "set_io {}[{}] {}\n".format(sig, bit, pin)
+                r += "set_io{} {}[{}] {}\n".format(misc, sig, bit, pin)
         else:
-            r += "set_io {} {}\n".format(sig, pins[0])
+            r += "set_io{} {} {}\n".format(misc, sig, pins[0])
     if named_pc:
         r += "\n" + "\n\n".join(named_pc)
     return r


### PR DESCRIPTION
Currently Misc() properties are ignored when generating the pcf constraint file for trellis.

To keep compatibility with existing platforms, Lattice's Diamond properties are translated to [nextpnr](https://github.com/YosysHQ/nextpnr/blob/master/ice40/pcf.cc#L55)'s.
Only PULLUP has been successfully tested (on icestick), but PULLUP_RESISTOR should be supported aswell, based on document found [here](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjd5s-X_5rsAhWCqaQKHcJqDu8QFjAAegQIARAC&url=http%3A%2F%2Fwww.latticesemi.com%2F~%2Fmedia%2FLatticeSemi%2FDocuments%2FTechnicalBriefs%2FSBTICETechnologyLibrary201608.pdf&usg=AOvVaw1uDChj2fJt4eVlfCCaii0C) (p91)

the IOStandard() properties are not supported by nextpnr, therefore nothing is done with them.