### PR TITLE
specials: Update mem.init files to match expectation of ecpbram

### DIFF
--- a/migen/fhdl/specials.py
+++ b/migen/fhdl/specials.py
@@ -386,8 +386,9 @@ class Memory(Special):
 
         if memory.init is not None:
             content = ""
+            formatter = "{:0" + str(int(memory.width / 4)) + "X}\n"
             for d in memory.init:
-                content += "{:x}\n".format(d)
+                content += formatter.format(d)
             memory_filename = add_data_file(gn(memory) + ".init", content)
 
             r += "initial begin\n"


### PR DESCRIPTION
ecpbram requires all lines in a memeory init file to be the same width.
This change ensures that leading zeros are padded out to the file.

Signed-off-by: Evan Lojewski <github@meklort.com>