### PR TITLE
zc706 platform: add SFP and Si5324 signals

### DIFF
--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -35,6 +35,19 @@ _io = [
         Subsignal("n", Pins("Y5"))
     ),
     ("sfp_tx_disable_n", 0, Pins("AA18"), IOStandard("LVCMOS25")),
+
+    ("si5324", 0,
+        Subsignal("rst_n", Pins("W23"), IOStandard("LVCMOS25")),
+        Subsignal("int", Pins("AJ25"), IOStandard("LVCMOS25"))
+    ),
+    ("si5324_clkin", 0,
+        Subsignal("p", Pins("AD20"), IOStandard("LVDS_25")),
+        Subsignal("n", Pins("AE20"), IOStandard("LVDS_25"))
+    ),
+    ("si5324_clkout", 0,
+        Subsignal("p", Pins("AC8")),
+        Subsignal("n", Pins("AC7"))
+    ),
 ]
 
 _connectors = [

--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -25,7 +25,6 @@ _io = [
             Misc("DIFF_TERM=TRUE"))
     ),
 
-    # signals same as on kc705, different pins
     ("sfp_tx", 0,
         Subsignal("p", Pins("W4")),
         Subsignal("n", Pins("W3"))

--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -24,6 +24,17 @@ _io = [
         Subsignal("n", Pins("AD19"), IOStandard("LVDS_25"),
             Misc("DIFF_TERM=TRUE"))
     ),
+
+    # signals same as on kc705, different pins
+    ("sfp_tx", 0,
+        Subsignal("p", Pins("W4")),
+        Subsignal("n", Pins("W3"))
+    ),
+    ("sfp_rx", 0,
+        Subsignal("p", Pins("Y6")),
+        Subsignal("n", Pins("Y5"))
+    ),
+    ("sfp_tx_disable_n", 0, Pins("AA18"), IOStandard("LVCMOS25")),
 ]
 
 _connectors = [


### PR DESCRIPTION
Signal definition added to the platform, as specified in UG954. This should be the minimum necessary for implementing DRTIO support.