### PR TITLE
Kc705/zc706 SFP signals changes

### DIFF
--- a/migen/build/platforms/kc705.py
+++ b/migen/build/platforms/kc705.py
@@ -213,13 +213,11 @@ _io = [
         Subsignal("p", Pins("K6")),
         Subsignal("n", Pins("K5"))
     ),
-    ("sfp_tx", 0,  # inverted prior to HW rev 1.1
-        Subsignal("p", Pins("H2")),
-        Subsignal("n", Pins("H1"))
-    ),
-    ("sfp_rx", 0,  # inverted prior to HW rev 1.1
-        Subsignal("p", Pins("G4")),
-        Subsignal("n", Pins("G3"))
+    ("sfp", 0,  # inverted prior to HW rev 1.1
+        Subsignal("txp", Pins("H2")),
+        Subsignal("txn", Pins("H1")),
+        Subsignal("rxp", Pins("G4")),
+        Subsignal("rxn", Pins("G3"))
     ),
     ("sfp_tx_disable_n", 0, Pins("Y20"), IOStandard("LVCMOS25")),
     ("sfp_rx_los", 0, Pins("P19"), IOStandard("LVCMOS25")),

--- a/migen/build/platforms/kc705.py
+++ b/migen/build/platforms/kc705.py
@@ -205,13 +205,11 @@ _io = [
         Subsignal("p", Pins("G8")),
         Subsignal("n", Pins("G7"))
     ),
-    ("user_sma_mgt_tx", 0,
-        Subsignal("p", Pins("K2")),
-        Subsignal("n", Pins("K1"))
-    ),
-    ("user_sma_mgt_rx", 0,
-        Subsignal("p", Pins("K6")),
-        Subsignal("n", Pins("K5"))
+    ("user_sma_mgt", 0,
+        Subsignal("txp", Pins("K2")),
+        Subsignal("txn", Pins("K1")),
+        Subsignal("rxp", Pins("K6")),
+        Subsignal("rxn", Pins("K5"))
     ),
     ("sfp", 0,  # inverted prior to HW rev 1.1
         Subsignal("txp", Pins("H2")),

--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -25,13 +25,11 @@ _io = [
             Misc("DIFF_TERM=TRUE"))
     ),
 
-    ("sfp_tx", 0,
-        Subsignal("p", Pins("W4")),
-        Subsignal("n", Pins("W3"))
-    ),
-    ("sfp_rx", 0,
-        Subsignal("p", Pins("Y6")),
-        Subsignal("n", Pins("Y5"))
+    ("sfp", 0,
+        Subsignal("txp", Pins("W4")),
+        Subsignal("txn", Pins("W3")),
+        Subsignal("rxp", Pins("Y6")),
+        Subsignal("rxn", Pins("Y5"))
     ),
     ("sfp_tx_disable_n", 0, Pins("AA18"), IOStandard("LVCMOS25")),
 


### PR DESCRIPTION
In DRTIO platform variants, there are slight differences in how GTX (used in KC705, ZC705 and Kasli-SoC) and GTP (used in Kasli) transceivers are defined and how they are passed to the interface.
This pull request is a part of three (this, nix-scripts and artiq) to bring the transceiver interface closer to reference (Kasli).

Migen part only changes the definitions of the signals to be identical in format with kasli/kasli-soc.

This PR should be merged in first.