### PR TITLE
kasli_soc: cdr_clk: replaced lvds_18 with lvds_25

### DIFF
--- a/migen/build/platforms/sinara/kasli_soc.py
+++ b/migen/build/platforms/sinara/kasli_soc.py
@@ -59,7 +59,7 @@ _io = [
     ("cdr_clk", 0,
         Subsignal("p", Pins("G7")),
         Subsignal("n", Pins("F7")),
-        IOStandard("LVDS_18"),
+        IOStandard("LVDS_25"),
     ),
     ("cdr_clk_clean_fabric", 0,
         Subsignal("p", Pins("AD23")),

--- a/migen/build/platforms/sinara/kasli_soc.py
+++ b/migen/build/platforms/sinara/kasli_soc.py
@@ -59,7 +59,7 @@ _io = [
     ("cdr_clk", 0,
         Subsignal("p", Pins("G7")),
         Subsignal("n", Pins("F7")),
-        IOStandard("LVDS_25"),
+        IOStandard("LVDS"),
     ),
     ("cdr_clk_clean_fabric", 0,
         Subsignal("p", Pins("AD23")),


### PR DESCRIPTION
cdr_clk input signal in kasli_soc had defined iostandard of LVDS_18, but that is not an option in Vivado. Changed it to LVDS, as it should've been in the first place.