### PR TITLE
vivado: improve timing during opt_design

### DIFF
--- a/migen/build/platforms/sinara/kasli.py
+++ b/migen/build/platforms/sinara/kasli.py
@@ -634,3 +634,5 @@ class Platform(XilinxPlatform):
             "set_property CFGBVS VCCO [current_design]",
             "set_property CONFIG_VOLTAGE 2.5 [current_design]",
             ])
+        if hw_rev == "v2.0":
+            self.toolchain.explore_opt_design = True

--- a/migen/build/xilinx/vivado.py
+++ b/migen/build/xilinx/vivado.py
@@ -84,6 +84,7 @@ class XilinxVivadoToolchain:
         self.bitstream_commands = []
         self.additional_commands = []
         self.pre_synthesis_commands = []
+        self.explore_opt_design = False
         self.with_phys_opt = False
         self.clocks = dict()
         self.false_paths = set()
@@ -118,7 +119,10 @@ class XilinxVivadoToolchain:
         tcl.append("report_timing_summary -file {}_timing_synth.rpt".format(build_name))
         tcl.append("report_utilization -hierarchical -file {}_utilization_hierarchical_synth.rpt".format(build_name))
         tcl.append("report_utilization -file {}_utilization_synth.rpt".format(build_name))
-        tcl.append("opt_design")
+        if self.explore_opt_design:
+            tcl.append("opt_design -directive ExploreWithRemap")
+        else:
+            tcl.append("opt_design")
         tcl.append("place_design")
         if self.with_phys_opt:
             tcl.append("phys_opt_design -directive AddRetime")


### PR DESCRIPTION
# Summary
Specify the `ExploreWithRemap` directive while optimizing the logic design in vivado.
Below is the description of the related directives in vivado 2021.1 (UG835):
```
ExploreArea - Run multiple passes of optimization, with an emphasis on reducing area.
ExploreWithRemap - Similar to ExploreArea but adds the remap optimization to compress logic levels.
AddRemap - Run the default optimization, and include LUT remapping to reduce logic levels.
```