### PR TITLE
zc706: la26_p pin fix

### DIFF
--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -130,7 +130,7 @@ _connectors = [
         "LA17_CC_N": "W24",
         "LA23_P": "P25",
         "LA23_N": "P26",
-        "LA26_P": "P28",
+        "LA26_P": "R28",
         "LA26_N": "T28",
         "PG_M2C": "U16.16",
         # ZC706 User Guide p. 68 col. 1


### PR DESCRIPTION
As mentioned here: https://git.m-labs.hk/M-Labs/artiq-zynq/issues/185 - LA26_P pin was "P28" but it should have been "R28". 

