### PR TITLE
Fix ECP5 BRAM packing

### DIFF
--- a/migen/fhdl/specials.py
+++ b/migen/fhdl/specials.py
@@ -388,7 +388,7 @@ class Memory(Special):
             content = ""
             formatter = "{:0" + str(int(memory.width / 4)) + "X}\n"
             for d in memory.init:
-                content += formatter.format(d)
+                content += formatter.format(d).zfill(int(memory.width / 4))
             memory_filename = add_data_file(gn(memory) + ".init", content)
 
             r += "initial begin\n"


### PR DESCRIPTION
The `ecpbram` utility expects the ROM data file to be in a fixed width (i.e. zero-padded) format.  migen should be able to adhere more strictly to that format without breaking other users of the ROM data file.