### PR TITLE
build/tools: language_by_filename, add SystemVerilog extensions to Verilog

### DIFF
--- a/migen/build/tools.py
+++ b/migen/build/tools.py
@@ -8,7 +8,7 @@ import ctypes
 
 def language_by_filename(name):
     extension = name.rsplit(".")[-1]
-    if extension in ["v", "vh", "vo"]:
+    if extension in ["v", "vh", "vo", "sv", "svh"]:
         return "verilog"
     if extension in ["vhd", "vhdl", "vho"]:
         return "vhdl"


### PR DESCRIPTION
## Overview
Adds `.sv` and `.svh` extensions to the list of Verilog file extensions in `build/tools.py: language_by_filename`

## Context
I was recently provided an encrypted library which contained both `.v` and `.sv` files. 
When calling `build/generic_platform.py: GenericPlatform.add_source_dir(...)`, the `.sv` were missed (unbeknownst to me).
When running a build, this led to an error in Vivado: `ERROR: [Synth 8-5809] Error generated from encrypted envelope.` - a tricky one to chase down!

It would be possible to add the `.sv` files one by one, though I can't see a reason one would import a directory and only want the `.v` files. Hence, I'm opening this PR to add SystemVerilog to the extensions list that matches Verilog.
