### PR TITLE
efc: add support for custom platform name

### DIFF
--- a/migen/build/platforms/sinara/efc.py
+++ b/migen/build/platforms/sinara/efc.py
@@ -378,10 +378,10 @@ _extensions = [
 class Platform(XilinxPlatform):
     userid = 0xffffffff
 
-    def __init__(self):
+    def __init__(self, name=None):
         XilinxPlatform.__init__(
             self, "xc7a100t-fgg484-3", _ios, _connectors,
-            toolchain="vivado")
+            toolchain="vivado", name=name)
         self.add_extension(_extensions)
 
         # https://support.xilinx.com/s/article/42036?language=en_US


### PR DESCRIPTION
This PR allows custom name to be assigned to efc platform from misoc repo.

This will affect the configuration flag "soc_platform" in artiq rust firmware.
(By default, `#[cfg(soc_platform = "efc")]` )

Related PR:
PR in [artiq](https://github.com/m-labs/artiq/pull/2223)
PR in [misoc](https://github.com/m-labs/misoc/pull/143)