### PR TITLE
zc706: correct the speed grade in the fpga part number 

### DIFF
--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -294,5 +294,5 @@ class Platform(XilinxPlatform):
     default_clk_period = 5  # 200 MHz
 
     def __init__(self):
-        XilinxPlatform.__init__(self, "xc7z045-ffg900-1", _io, _connectors,
+        XilinxPlatform.__init__(self, "xc7z045-ffg900-2", _io, _connectors,
             toolchain="vivado")


### PR DESCRIPTION
Xilinx ZC706 Evaluation Board has a XC7Z045 FFG900 SoC in [–2 speed grade](https://www.xilinx.com/products/boards-and-kits/ek-z7-zc706-g.html) instead of -1 speed grade.