### PR TITLE
kasli_soc: add user_led2

### DIFF
--- a/migen/build/platforms/sinara/kasli_soc.py
+++ b/migen/build/platforms/sinara/kasli_soc.py
@@ -5,6 +5,7 @@ from migen.build.xilinx import XilinxPlatform
 _io = [
     ("user_led", 0, Pins("AF19"), IOStandard("LVCMOS25")),
     ("user_led", 1, Pins("AF23"), IOStandard("LVCMOS25")),
+    ("user_led", 2, Pins("A23"), IOStandard("LVCMOS25")),
 
     ("serial", 0,
         Subsignal("tx", Pins("Y18")),


### PR DESCRIPTION
_WIP pending testing_
Add user_led 2 to description of Kasli-SoC.

- [ ] Testing completed.