### PR TITLE
fhdl/tracer: handle `STORE_DEREF` for local, cell, and free variables

### DIFF
--- a/migen/fhdl/tracer.py
+++ b/migen/fhdl/tracer.py
@@ -59,9 +59,13 @@ def get_var_name(frame):
             return code.co_varnames[name_index]
         elif opc == "STORE_DEREF":
             name_index = int(code.co_code[index+1])
-            if version_info >= (3, 11):
-                name_index -= code.co_nlocals
-            return code.co_cellvars[name_index]
+            if name_index < code.co_nlocals:
+                return code.co_varnames[name_index]
+            name_index -= code.co_nlocals
+            if name_index < len(code.co_cellvars):
+                return code.co_cellvars[name_index]
+            name_index -= len(code.co_cellvars)
+            return code.co_freevars[name_index]
         elif opc in _load_build_opcodes:
             index += _load_build_opcodes[opc]
         else:


### PR DESCRIPTION
### Description

Removed version-specific handling of the `STORE_DEREF` opcode and implemented comprehensive support for local, cell, and free variables.

Closes #288

Tested in python `3.12` and `3.11`. 

Test Results:
```
python3.12-misoc> ok
python3.12-misoc> test_latency (misoc.test.test_duc.TestPhasedDUC.test_latency) ... CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> ok
python3.12-misoc> test_neg (misoc.test.test_duc.TestPhasedDUC.test_neg) ... CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> ok
python3.12-misoc> test_quad (misoc.test.test_duc.TestPhasedDUC.test_quad) ... CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> CosSin LUT 10 bit deep, 36 bit wide
python3.12-misoc> ok
python3.12-misoc> test_init (misoc.test.test_cic.TestCIC.test_init) ... ok
python3.12-misoc> test_seq (misoc.test.test_cic.TestCIC.test_seq) ... ok
python3.12-misoc> test_i2c (misoc.test.test_i2c.TestI2C.test_i2c) ... ok
python3.12-misoc> test_trxpaths_config (misoc.test.test_pcs_1000basex.TestPCS.test_trxpaths_config) ... ok
python3.12-misoc> test_trxpaths_data (misoc.test.test_pcs_1000basex.TestPCS.test_trxpaths_data) ... ok
python3.12-misoc> ----------------------------------------------------------------------
python3.12-misoc> Ran 34 tests in 9.422s
python3.12-misoc> OK
python3.12-misoc> Finished executing setuptoolsCheckPhase
```