### PR TITLE
zc706: AJ7 net name fix

### DIFF
--- a/migen/build/platforms/zc706.py
+++ b/migen/build/platforms/zc706.py
@@ -68,7 +68,7 @@ _connectors = [
     ("HPC", {
         # ZC706 User Guide p. 66 col. 1
         "DP1_M2C_P": "AJ8",
-        "DP2_M2C_N": "AJ7",
+        "DP1_M2C_N": "AJ7",
         "DP2_M2C_P": "AG8",
         "DP2_M2C_N": "AG7",
         "DP3_M2C_P": "AE8",


### PR DESCRIPTION
Fix the net name for AJ7 pin
![image](https://github.com/user-attachments/assets/9896aee1-6af0-44e8-9285-fc763ba83f85)
