### PR TITLE
Implement almost_full and almost_empty for Synchronous FIFOs

### DIFF
--- a/migen/genlib/fifo.py
+++ b/migen/genlib/fifo.py
@@ -152,19 +152,11 @@ class SyncFIFO(Module, _FIFOInterface):
 
         if hi_wm is not None:
             self.almost_full = Signal()
-            if hi_wm.bit_count() == 1:
-                self.comb += self.almost_full.eq(
-                    reduce(or_, [level_i for level_i in self.level[log2_int(hi_wm):]]))
-            else:
-                self.comb += self.almost_full.eq(self.level >= hi_wm)
+            self.comb += self.almost_full.eq(self.level >= hi_wm)
 
         if lo_wm is not None:
             self.almost_empty = Signal()
-            if lo_wm.bit_count() == 1:
-                self.comb += self.almost_empty.eq(
-                    reduce(and_, [~level_i for level_i in self.level[log2_int(lo_wm):]]) | (self.level == lo_wm))
-            else:
-                self.comb += self.almost_empty.eq(self.level <= lo_wm)
+            self.comb += self.almost_empty.eq(self.level <= lo_wm)
 
 
 class SyncFIFOBuffered(Module, _FIFOInterface):
@@ -194,19 +186,11 @@ class SyncFIFOBuffered(Module, _FIFOInterface):
 
         if hi_wm is not None:
             self.almost_full = Signal()
-            if hi_wm.bit_count() == 1:
-                self.comb += self.almost_full.eq(
-                    reduce(or_, [level_i for level_i in self.level[log2_int(hi_wm):]]))
-            else:
-                self.comb += self.almost_full.eq(self.level >= hi_wm)
+            self.comb += self.almost_full.eq(self.level >= hi_wm)
 
         if lo_wm is not None:
             self.almost_empty = Signal()
-            if lo_wm.bit_count() == 1:
-                self.comb += self.almost_empty.eq(
-                    reduce(and_, [~level_i for level_i in self.level[log2_int(lo_wm):]]) | (self.level == lo_wm))
-            else:
-                self.comb += self.almost_empty.eq(self.level <= lo_wm)
+            self.comb += self.almost_empty.eq(self.level <= lo_wm)
 
 
 class AsyncFIFO(Module, _FIFOInterface):

--- a/migen/genlib/fifo.py
+++ b/migen/genlib/fifo.py
@@ -1,6 +1,3 @@
-from functools import reduce
-from operator import and_, or_
-
 from migen.fhdl.structure import *
 from migen.fhdl.module import Module
 from migen.fhdl.specials import Memory, READ_FIRST


### PR DESCRIPTION
## Description
This PR introduces FIFO watermark configuration.
- When the FIFO level reaches the high watermark (inclusive), `almost_full` is asserted.
- When the FIFO level does not exceed the low watermark (inclusive), `almost_empty` is asserted.