### PR TITLE
Fix Signal initialization when max=1

### DIFF
--- a/migen/fhdl/structure.py
+++ b/migen/fhdl/structure.py
@@ -369,6 +369,9 @@ class Signal(_Value):
         if bits_sign is None:
             if min is None:
                 min = 0
+                # handle Signal(max=1) condition
+                if max == 1:
+                    max = 2
             if max is None:
                 max = 2
             max -= 1  # make both bounds inclusive


### PR DESCRIPTION
It's used in migen's `Memory` type:

https://github.com/m-labs/migen/blob/c19ae9f8ae162ffe2d310a92bfce53ac2a821bc8/migen/fhdl/specials.py#L291-L298

This bug causes `Memory` initialization to fail when depth=1.

I found this(assert fail) when using `WS2812` with `nleds=1` in LiteX.