### PR TITLE
phaser: Add arg to specify FPGA speed grade

### DIFF
--- a/migen/build/platforms/sinara/phaser.py
+++ b/migen/build/platforms/sinara/phaser.py
@@ -273,9 +273,13 @@ _extensions = [
 
 class Platform(XilinxPlatform):
     userid = 0xffffffff
-    def __init__(self):
+    def __init__(self, speed_grade="-2"):
+        if speed_grade == "-2":
+            fpga = "xc7a100t-fgg484-2"
+        elif speed_grade == "-3":
+            fpga = "xc7a100t-fgg484-3"
         XilinxPlatform.__init__(
-                self, "xc7a100t-fgg484-2", _ios, _connectors,
+                self, fpga, _ios, _connectors,
                 toolchain="vivado")
         self.add_extension(_extensions)
         self.add_platform_command(


### PR DESCRIPTION
[Phaser](https://github.com/sinara-hw/Phaser) uses -3 speed grade instead of -2 in all hardware revisions (v1.1 and v1.0).

I flashed it successfully with -3 speed grade bitstream and it passed the artiq_sinara_tester test case.

![image](https://github.com/user-attachments/assets/40eefc61-bfaa-463d-b331-0ecc49e7d3e0)