### PR TITLE
toolchain: Add IOB attribute

### DIFF
--- a/migen/build/lattice/icestorm.py
+++ b/migen/build/lattice/icestorm.py
@@ -84,7 +84,10 @@ class LatticeIceStormToolchain:
         "ars_false_path": None,  # user-defined attribute
 
         # ice40 does not have a shift register primitive.
-        "no_shreg_extract": None
+        "no_shreg_extract": None,
+
+        # ice40 I/O registers must be declared by PIN_TYPE of SB_IO
+        "iob": None
     }
 
     special_overrides = common.lattice_ice40_special_overrides

--- a/migen/build/xilinx/vivado.py
+++ b/migen/build/xilinx/vivado.py
@@ -75,6 +75,7 @@ class XilinxVivadoToolchain:
         "keep": ("dont_touch", "true"),
         "no_retiming": ("dont_touch", "true"),
         "async_reg": ("async_reg", "true"),
+        "iob": ("iob", "true"),
         "mr_ff": ("mr_ff", "true"),  # user-defined attribute
         "ars_ff1": ("ars_ff1", "true"),  # user-defined attribute
         "ars_ff2": ("ars_ff2", "true"),  # user-defined attribute


### PR DESCRIPTION
This adds an IOB attribute for signals and instances.

In vivado, IOB attribute tells the synthesizer to place the register in the I/O block, if applicable.
See the necessary conditions to place the register in the I/O block.
https://adaptivesupport.amd.com/s/article/66668?language=en_US