### PR TITLE
feature: Add RoundRobin SP_TIMESLICE switch policy

### DIFF
--- a/migen/genlib/roundrobin.py
+++ b/migen/genlib/roundrobin.py
@@ -1,17 +1,21 @@
 from migen.fhdl.structure import *
 from migen.fhdl.module import Module
 
-
-(SP_WITHDRAW, SP_CE) = range(2)
-
+(SP_WITHDRAW, SP_CE, SP_TIMESLICE) = range(3)
 
 class RoundRobin(Module):
-    def __init__(self, n, switch_policy=SP_WITHDRAW):
+    def __init__(self, n, switch_policy=SP_WITHDRAW, max_cycles=64):
         self.request = Signal(n)
         self.grant = Signal(max=max(2, n))
         self.switch_policy = switch_policy
+
         if self.switch_policy == SP_CE:
             self.ce = Signal()
+
+        if self.switch_policy == SP_TIMESLICE:
+            self.transok = Signal(n)
+            self.max_cycles = max_cycles
+            self.counter = Signal(max=max_cycles + 1)
 
         ###
 
@@ -23,19 +27,37 @@ class RoundRobin(Module):
                     t = j % n
                     switch = [
                         If(self.request[t],
-                            self.grant.eq(t)
+                           self.grant.eq(t)
                         ).Else(
                             *switch
                         )
                     ]
+
                 if self.switch_policy == SP_WITHDRAW:
                     case = [If(~self.request[i], *switch)]
+
+                elif self.switch_policy == SP_TIMESLICE:
+                    case = [
+                        If((~self.request[i]) | ((self.counter >= self.max_cycles) & self.transok[i]),
+                           self.counter.eq(0),  # reset counter when switching
+                           *switch
+                        ).Else(
+                           self.counter.eq(self.counter + 1)
+                        )
+                    ]
+
                 else:
-                    case = switch
+                    case = switch  # SP_CE
+
                 cases[i] = case
+
             statement = Case(self.grant, cases)
+
             if self.switch_policy == SP_CE:
                 statement = If(self.ce, statement)
+
             self.sync += statement
+
         else:
             self.comb += self.grant.eq(0)
+

--- a/migen/test/support.py
+++ b/migen/test/support.py
@@ -9,5 +9,5 @@ class SimCase:
     def test_to_verilog(self):
         verilog.convert(self.tb)
 
-    def run_with(self, generator):
-        run_simulation(self.tb, generator)
+    def run_with(self, generator, **kwargs):
+        run_simulation(self.tb, generator, **kwargs)

--- a/migen/test/test_roundrobin.py
+++ b/migen/test/test_roundrobin.py
@@ -1,0 +1,48 @@
+import unittest
+from itertools import count
+
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from migen import *
+from migen.genlib.roundrobin import RoundRobin, SP_TIMESLICE
+from migen.test.support import SimCase
+
+class RoundRobinCase(SimCase, unittest.TestCase):
+    class TestBench(Module):
+        def __init__(self):
+            self.submodules.dut = RoundRobin(n=2, switch_policy=SP_TIMESLICE, max_cycles=8)
+
+    def test_grant_switch(self, vcd=True):
+        def gen():
+            expected_grants = [0]*10 + [1]*10 + [0]*10
+            observed_grants = []
+            for cycle in count():
+                if cycle == 0:
+                    yield self.tb.dut.request[0].eq(1)
+                    yield self.tb.dut.request[1].eq(1)
+                    yield
+                elif cycle == 31:
+                    break
+                else:
+                    grant = (yield self.tb.dut.grant)
+                    transok = (yield self.tb.dut.transok)
+
+                    observed_grants.append(grant)
+                    if(yield self.tb.dut.transok[grant]):
+                        self.assertLessEqual((yield self.tb.dut.counter), 9)
+
+                    if(yield self.tb.dut.transok[grant]):
+                        yield self.tb.dut.transok[grant].eq(0)
+                    else:
+                        yield self.tb.dut.transok[grant].eq(1)
+                    yield
+                    
+            self.assertEqual(observed_grants, expected_grants)
+
+
+        if vcd:
+            self.run_with(gen(), vcd_name='roundrobin.vcd')
+        else:
+            self.run_with(gen())

--- a/migen/test/test_roundrobin.py
+++ b/migen/test/test_roundrobin.py
@@ -1,10 +1,6 @@
 import unittest
 from itertools import count
 
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 from migen import *
 from migen.genlib.roundrobin import RoundRobin, SP_TIMESLICE
 from migen.test.support import SimCase


### PR DESCRIPTION
## Summary

This pull request introduces a new arbitration switch policy named `SP_TIMESLICE` to the `RoundRobin` module in `migen.genlib.roundrobin`. 

## Motivation

Consider an arbiter that grants access to a shared book for two writers. One writer just wants to sign their name, while the other plans to write an entire chapter. The question is: **"Once the chapter writer starts using the book, is it fair for the signer to wait until the entire chapter is finished, just to sign their name?"**. 
This illustrates a common problem in resource arbitration where long or variable transactions from one master can block others indefinitely, or for a very long time. The `SP_TIMESLICE` policy addresses this by limiting how long a master can hold the grant (`max_cycles`), ensuring that long transactions don’t block others, improving the resources allocation and avoiding deadlocks in shared-resource systems.

## Main Changes

- `migen/genlib/roundrobin.py`: 
    - Added `SP_TIMESLICE` constant and modified the RoundRobin module to handle this new policy.
    - Introduced a new signal:
        - `transok`: Input signal (one per master) indicating whether the last transaction was successfully completed. It prevents premature switching in the middle of an active transaction;

- `migen/test/test_roundrobin.py`: 
    - Add `SP_TIMESLICE` unit test

- `migen/genlib/support.py`: 
    - Pass optional `**kwargs` to `SimCase.run_with()` method, enabling the VCD generation directly from this method.

## Tests

A new test case, `test_grant_switch`, was added to `test_roundrobin.py` to validate the `SP_TIMESLICE` behavior. The test ensures that grant switching occurs when the internal counter reaches `max_cycles` and no transaction is currently in progress. To run the test, execute the command below from the `migen/migen/test` directory.

```
python3 -m unittest test_roundrobin.py
```

## Evidences

### Evidence 1: VCD of unit test
As shown in the image below, the `grant` switches when `max_cycles` is reached and no transaction is in progress. This VCD waveform was generated using `SimCase.run_with()` with the `vcd_name` parameter set accordingly. The snapshot displays the relevant signals in the GTKWave interface.

<img width="765" height="162" alt="image" src="https://github.com/user-attachments/assets/c3b2daa6-56d4-4f15-9e7e-f4d9e1fd6f9d" />

### Evidence 2: Vivado FPGA validation

The image below shows the waveform from the Vivado simulator using the RoundRobin arbiter with the implemented `SP_TIMESLICE` policy. In this simulation, two Wishbone masters requests read/write access at the same time to a shared slave memory. The masters' requests can be seen by the CYC and STB signals, while the slave's ACK signal is connected to the arbiter's `transok` input. The equivalent Verilog design was also implemented and validated on a Xilinx Artix-7 FPGA.

<img width="1452" height="627" alt="image" src="https://github.com/user-attachments/assets/cb680720-5497-4ae0-9c6c-af5f78ac3512" />

## Checklist
- [x] Code changes compile without errors;
- [x] Feature covered by unit tests;
- [x] Follows Migen code style and conventions;
- [x] Backwards-compatible;